### PR TITLE
Major simplification

### DIFF
--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,12 +1,8 @@
-use p3_air::{AirBuilder, BaseAir};
+use p3_air::AirBuilder;
 
 pub mod check;
 pub mod folder;
 pub mod symbolic;
-
-pub trait TwoStagedAir<F>: BaseAir<F> {
-    fn stage_2_width(&self) -> usize;
-}
 
 pub trait TwoStagedBuilder: AirBuilder {
     fn stage_2(&self) -> Self::M;

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,8 +1,12 @@
-use p3_air::AirBuilder;
+use p3_air::{AirBuilder, BaseAir};
 
 pub mod check;
 pub mod folder;
 pub mod symbolic;
+
+pub trait TwoStagedAir<F>: BaseAir<F> {
+    fn stage_2_width(&self) -> usize;
+}
 
 pub trait TwoStagedBuilder: AirBuilder {
     fn stage_2(&self) -> Self::M;

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -317,7 +317,7 @@ mod tests {
             lookups: CS::Odd.lookups(),
         })
         .unwrap();
-        System::new([("even", even), ("odd", odd)].into_iter())
+        System::new([even, odd])
     }
 
     #[test]
@@ -360,7 +360,7 @@ mod tests {
             ],
         };
         let claim = Claim {
-            circuit_name: "even".into(),
+            circuit_idx: 0,
             args: vec![f(4), f(1)],
         };
         let fri_parameters = FriParameters {

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -51,7 +51,7 @@ impl SystemWitness<Val> {
     pub fn stage_2_from_symbolic_lookups(
         &self,
         circuit_lookups: &[Vec<Lookup<SymbolicExpression<Val>>>],
-    ) -> Box<dyn Fn(&[Val], &mut Vec<Val>) -> Self> {
+    ) -> Box<dyn Fn(&[Val]) -> (Self, Vec<Val>)> {
         let lookups = self
             .circuits
             .iter()
@@ -76,8 +76,9 @@ impl SystemWitness<Val> {
     pub fn stage_2_from_lookups(
         &self,
         lookups: Vec<Vec<Vec<Lookup<Val>>>>,
-    ) -> Box<dyn Fn(&[Val], &mut Vec<Val>) -> Self> {
-        Box::new(move |values, intermediate_accumulators| {
+    ) -> Box<dyn Fn(&[Val]) -> (Self, Vec<Val>)> {
+        Box::new(move |values| {
+            let mut intermediate_accumulators = vec![];
             let lookup_challenge = values[0];
             let fingenprint_challenge = values[1];
             let mut accumulator = values[2];
@@ -106,7 +107,7 @@ impl SystemWitness<Val> {
                     CircuitWitness { trace }
                 })
                 .collect();
-            Self { circuits }
+            (Self { circuits }, intermediate_accumulators)
         })
     }
 }

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -17,13 +17,13 @@ pub struct Lookup<Expr> {
     pub args: Vec<Expr>,
 }
 
-pub struct LookupAir<A, F> {
+pub struct LookupAir<A> {
     pub inner_air: A,
-    pub lookups: Vec<Lookup<SymbolicExpression<F>>>,
+    pub lookups: Vec<Lookup<SymbolicExpression<Val>>>,
 }
 
-impl<A, F> LookupAir<A, F> {
-    pub fn new(inner_air: A, lookups: Vec<Lookup<SymbolicExpression<F>>>) -> Self {
+impl<A> LookupAir<A> {
+    pub fn new(inner_air: A, lookups: Vec<Lookup<SymbolicExpression<Val>>>) -> Self {
         Self { inner_air, lookups }
     }
 }
@@ -112,7 +112,7 @@ impl SystemWitness<Val> {
     }
 }
 
-impl<A> BaseAir<Val> for LookupAir<A, Val>
+impl<A> BaseAir<Val> for LookupAir<A>
 where
     A: BaseAir<Val>,
 {
@@ -121,7 +121,7 @@ where
     }
 }
 
-impl<A> BaseAirWithPublicValues<Val> for LookupAir<A, Val>
+impl<A> BaseAirWithPublicValues<Val> for LookupAir<A>
 where
     A: BaseAir<Val>,
 {
@@ -130,7 +130,7 @@ where
     }
 }
 
-impl<A> TwoStagedAir<Val> for LookupAir<A, Val>
+impl<A> TwoStagedAir<Val> for LookupAir<A>
 where
     A: BaseAir<Val>,
 {
@@ -139,7 +139,7 @@ where
     }
 }
 
-impl<A, AB> Air<AB> for LookupAir<A, Val>
+impl<A, AB> Air<AB> for LookupAir<A>
 where
     A: Air<AB>,
     AB: AirBuilderWithPublicValues<F = Val> + TwoStagedBuilder,
@@ -306,7 +306,7 @@ mod tests {
                 .assert_one(input * input_inverse);
         }
     }
-    fn system() -> System<LookupAir<CS, Val>> {
+    fn system() -> System<LookupAir<CS>> {
         let even = Circuit::from_air(LookupAir {
             inner_air: CS::Even,
             lookups: CS::Even.lookups(),

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1,6 +1,6 @@
 use crate::{
     builder::folder::ProverConstraintFolder,
-    system::{Name, System, SystemWitness},
+    system::{System, SystemWitness},
     types::{Challenger, Domain, ExtVal, PackedExtVal, PackedVal, Pcs, StarkConfig, Val},
 };
 use p3_air::{Air, BaseAirWithPublicValues};
@@ -14,8 +14,18 @@ use serde::{Deserialize, Serialize};
 use std::{cmp::min, iter::once};
 
 pub struct Claim {
-    pub circuit_name: Name,
+    pub circuit_idx: usize,
     pub args: Vec<Val>,
+}
+
+impl Claim {
+    #[inline]
+    pub fn empty() -> Self {
+        Self {
+            circuit_idx: 0,
+            args: vec![],
+        }
+    }
 }
 
 type Commitment = <Pcs as PcsTrait<ExtVal, Challenger>>::Commitment;
@@ -71,7 +81,7 @@ impl<A: BaseAirWithPublicValues<Val> + for<'a> Air<ProverConstraintFolder<'a>>> 
         // observe the claim
         // this has to be done before generating the lookup argument challenge
         // otherwise the lookup argument can be attacked
-        let circuit_index = Val::from_usize(*self.circuit_names.get(&claim.circuit_name).unwrap());
+        let circuit_index = Val::from_usize(claim.circuit_idx);
         challenger.observe(circuit_index);
         challenger.observe_slice(&claim.args);
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,5 +1,8 @@
 use crate::{
-    builder::symbolic::{SymbolicAirBuilder, get_max_constraint_degree, get_symbolic_constraints},
+    builder::{
+        TwoStagedAir,
+        symbolic::{SymbolicAirBuilder, get_max_constraint_degree, get_symbolic_constraints},
+    },
     ensure_eq,
     types::Val,
 };
@@ -60,11 +63,14 @@ pub struct SystemWitness<Val> {
     pub circuits: Vec<CircuitWitness<Val>>,
 }
 
-impl<A: BaseAirWithPublicValues<Val> + Air<SymbolicAirBuilder<Val>>> Circuit<A> {
-    pub fn from_air(air: A, stage_2_width: usize) -> Result<Self, String> {
+impl<A: BaseAirWithPublicValues<Val> + TwoStagedAir<Val> + Air<SymbolicAirBuilder<Val>>>
+    Circuit<A>
+{
+    pub fn from_air(air: A) -> Result<Self, String> {
         let io_size = air.num_public_values();
         ensure_eq!(io_size, MIN_IO_SIZE, "Incompatible IO size");
         let stage_1_width = air.width();
+        let stage_2_width = air.stage_2_width();
         let preprocessed_width = air.preprocessed_trace().map_or(0, |mat| mat.width());
         let constraint_count = get_symbolic_constraints(
             &air,

--- a/src/system.rs
+++ b/src/system.rs
@@ -8,9 +8,6 @@ use crate::{
 };
 use p3_air::{Air, BaseAirWithPublicValues};
 use p3_matrix::{Matrix, dense::RowMajorMatrix};
-use std::collections::BTreeMap as Map;
-
-pub type Name = String;
 
 /// Each circuit is required to have at least 4 arguments. Namely, the lookup challenge,
 /// fingerprint challenge, current accumulator and next accumulator
@@ -18,28 +15,13 @@ pub const MIN_IO_SIZE: usize = 4;
 
 pub struct System<A> {
     pub circuits: Vec<Circuit<A>>,
-    pub circuit_names: Map<Name, usize>,
 }
 
 impl<A> System<A> {
-    pub fn new<Str: ToString, Iter: Iterator<Item = (Str, Circuit<A>)>>(iter: Iter) -> Self {
-        let mut circuits = vec![];
-        let mut circuit_names = Map::new();
-        iter.for_each(|(name, circuit)| {
-            let idx = circuits.len();
-            if let Some(prev_idx) = circuit_names.insert(name.to_string(), idx) {
-                eprintln!(
-                    "Warning: circuit of name `{}` was redefined",
-                    name.to_string()
-                );
-                circuits[prev_idx] = circuit;
-            } else {
-                circuits.push(circuit);
-            }
-        });
+    #[inline]
+    pub fn new(circuits: impl IntoIterator<Item = Circuit<A>>) -> Self {
         Self {
-            circuits,
-            circuit_names,
+            circuits: circuits.into_iter().collect(),
         }
     }
 }

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -338,6 +338,7 @@ mod tests {
     use super::*;
     use crate::{
         benchmark,
+        builder::TwoStagedAir,
         prover::Claim,
         system::{Circuit, CircuitWitness, MIN_IO_SIZE, SystemWitness},
         types::{FriParameters, new_stark_config},
@@ -360,6 +361,11 @@ mod tests {
     impl<F> BaseAirWithPublicValues<F> for CS {
         fn num_public_values(&self) -> usize {
             MIN_IO_SIZE
+        }
+    }
+    impl<F> TwoStagedAir<F> for CS {
+        fn stage_2_width(&self) -> usize {
+            1
         }
     }
     impl<AB> Air<AB> for CS
@@ -392,10 +398,8 @@ mod tests {
         }
     }
     fn system() -> System<CS> {
-        // the prover does not support 0 width traces yet
-        let min_stage_2_width = 1;
-        let pythagorean_circuit = Circuit::from_air(CS::Pythagorean, min_stage_2_width).unwrap();
-        let complex_circuit = Circuit::from_air(CS::Complex, min_stage_2_width).unwrap();
+        let pythagorean_circuit = Circuit::from_air(CS::Pythagorean).unwrap();
+        let complex_circuit = Circuit::from_air(CS::Complex).unwrap();
         System::new(
             [
                 ("pythagorean", pythagorean_circuit),

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -408,10 +408,8 @@ mod tests {
             .into_iter(),
         )
     }
-    fn dummy_stage_2_trace(
-        log_heights: &[usize],
-        accumulators: &mut Vec<Val>,
-    ) -> SystemWitness<Val> {
+    fn dummy_stage_2_trace(log_heights: &[usize]) -> (SystemWitness<Val>, Vec<Val>) {
+        let mut accumulators = vec![];
         let circuits = log_heights
             .iter()
             .map(|log_height| {
@@ -421,7 +419,7 @@ mod tests {
                 CircuitWitness { trace }
             })
             .collect();
-        SystemWitness { circuits }
+        (SystemWitness { circuits }, accumulators)
     }
 
     #[test]
@@ -460,7 +458,7 @@ mod tests {
             &config,
             &dummy_claim,
             witness,
-            Box::new(|_, accumulators| dummy_stage_2_trace(&[2, 1], accumulators)),
+            Box::new(|_| dummy_stage_2_trace(&[2, 1])),
         );
         system.verify(&config, &dummy_claim, &proof).unwrap();
     }
@@ -506,7 +504,7 @@ mod tests {
                 &config,
                 &dummy_claim,
                 witness,
-                Box::new(|_, accumulators| dummy_stage_2_trace(&[LOG_HEIGHT; 2], accumulators))
+                Box::new(|_| dummy_stage_2_trace(&[LOG_HEIGHT; 2]))
             ),
             "proof: "
         );

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -44,12 +44,7 @@ impl<A: BaseAirWithPublicValues<Val> + for<'a> Air<VerifierConstraintFolder<'a>>
         // there must be at least one circuit
         ensure!(num_circuits > 0, VerificationError::InvalidSystem);
         // check the claim
-        let circuit_index = Val::from_usize(
-            *self
-                .circuit_names
-                .get(&claim.circuit_name)
-                .ok_or(VerificationError::InvalidClaim)?,
-        );
+        let circuit_index = Val::from_usize(claim.circuit_idx);
         // stage 1 round
         ensure_eq!(
             stage_1_opened_values.len(),
@@ -400,13 +395,7 @@ mod tests {
     fn system() -> System<CS> {
         let pythagorean_circuit = Circuit::from_air(CS::Pythagorean).unwrap();
         let complex_circuit = Circuit::from_air(CS::Complex).unwrap();
-        System::new(
-            [
-                ("pythagorean", pythagorean_circuit),
-                ("complex", complex_circuit),
-            ]
-            .into_iter(),
-        )
+        System::new([pythagorean_circuit, complex_circuit])
     }
     fn dummy_stage_2_trace(log_heights: &[usize]) -> (SystemWitness<Val>, Vec<Val>) {
         let mut accumulators = vec![];
@@ -442,11 +431,8 @@ mod tests {
                 },
             ],
         };
-        // lookup arguments not yet implemented so the claim doesn't matter
-        let dummy_claim = Claim {
-            circuit_name: "complex".into(),
-            args: vec![],
-        };
+        // there are no lookups
+        let dummy_claim = Claim::empty();
         let fri_parameters = FriParameters {
             log_blowup: 1,
             log_final_poly_len: 0,
@@ -487,11 +473,8 @@ mod tests {
                 },
             ],
         };
-        // lookup arguments not yet implemented so the claim doesn't matter
-        let dummy_claim = Claim {
-            circuit_name: "complex".into(),
-            args: vec![],
-        };
+        // there are no lookups
+        let dummy_claim = Claim::empty();
         let fri_parameters = FriParameters {
             log_blowup: 1,
             log_final_poly_len: 0,


### PR DESCRIPTION
Circuits no longer carry names.
Removed TwoStagedAir trait.
Prove does not require a dynamic closure.
Instead, the stage 2 is automatically generated using the LookupAir struct.