### PR TITLE
chore: several minor improvements

### DIFF
--- a/src/builder/symbolic.rs
+++ b/src/builder/symbolic.rs
@@ -120,7 +120,7 @@ impl<F: Field> SymbolicExpression<F> {
         preprocessed: Option<&[Var]>,
     ) -> Expr {
         match self {
-            Self::Variable(var) => match var.entry {
+            Self::Variable(var) => match &var.entry {
                 Entry::Main { offset: 0 } => row[var.index].clone().into(),
                 Entry::Preprocessed { offset: 0 } => {
                     preprocessed.unwrap()[var.index].clone().into()
@@ -129,17 +129,14 @@ impl<F: Field> SymbolicExpression<F> {
             },
             Self::Constant(c) => (*c).into(),
             Self::Add { x, y, .. } => {
-                x.interpret::<Expr, Var>(row, preprocessed)
-                    + y.interpret::<Expr, Var>(row, preprocessed)
+                x.interpret(row, preprocessed) + y.interpret(row, preprocessed)
             }
             Self::Sub { x, y, .. } => {
-                x.interpret::<Expr, Var>(row, preprocessed)
-                    - y.interpret::<Expr, Var>(row, preprocessed)
+                x.interpret(row, preprocessed) - y.interpret(row, preprocessed)
             }
-            Self::Neg { x, .. } => -x.interpret::<Expr, Var>(row, preprocessed),
+            Self::Neg { x, .. } => -x.interpret(row, preprocessed),
             Self::Mul { x, y, .. } => {
-                x.interpret::<Expr, Var>(row, preprocessed)
-                    * y.interpret::<Expr, Var>(row, preprocessed)
+                x.interpret(row, preprocessed) * y.interpret(row, preprocessed)
             }
             _ => unimplemented!(),
         }

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -249,7 +249,7 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a>>> System<A> {
                 pcs,
                 1 << log_degree,
             );
-            let zeta_next = trace_domain.next_point(zeta).unwrap();
+            let zeta_next = zeta * trace_domain.subgroup_generator();
             round1_openings.push(vec![zeta, zeta_next]);
             round2_openings.push(vec![zeta, zeta_next]);
             round3_openings.extend(vec![vec![zeta]; quotient_degree]);

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -53,8 +53,8 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a>>> System<A> {
 
         // the last accumulator should be 0
         ensure_eq!(
-            *intermediate_accumulators.last().unwrap(),
-            Val::from_u32(0),
+            intermediate_accumulators.last(),
+            Some(&Val::ZERO),
             VerificationError::UnbalancedChannel
         );
 
@@ -128,7 +128,7 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a>>> System<A> {
                     )
                 })
                 .collect::<Vec<_>>();
-            let zeta_next = trace_domain.next_point(zeta).unwrap();
+            let zeta_next = zeta * trace_domain.subgroup_generator();
             if let Some(i) = self.preprocessed_indices[i] {
                 let preprocessed_opened_values = preprocessed_opened_values.as_ref().unwrap();
                 preprocessed_trace_evaluations.push((


### PR DESCRIPTION
* Clean up some type parameters
* Remove reversed assumption from fingerprint function
* Use `const` values for a few `Val` instantiations where possible
* Inline implementation of `zeta_next`, removing the `.unwrap()`s