### PR TITLE
Bump Plonky3 and add prover cost analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,12 +194,13 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -210,13 +211,13 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -239,15 +240,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -338,8 +339,8 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "p3-air"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -348,8 +349,8 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -361,13 +362,14 @@ dependencies = [
 
 [[package]]
 name = "p3-commit"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
  "p3-dft",
  "p3-field",
+ "p3-interpolation",
  "p3-matrix",
  "p3-util",
  "serde",
@@ -375,8 +377,8 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -389,8 +391,8 @@ dependencies = [
 
 [[package]]
 name = "p3-field"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -404,8 +406,8 @@ dependencies = [
 
 [[package]]
 name = "p3-fri"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
@@ -425,8 +427,8 @@ dependencies = [
 
 [[package]]
 name = "p3-goldilocks"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "num-bigint",
  "p3-challenger",
@@ -444,8 +446,8 @@ dependencies = [
 
 [[package]]
 name = "p3-interpolation"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -455,8 +457,8 @@ dependencies = [
 
 [[package]]
 name = "p3-keccak"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "p3-symmetric",
  "p3-util",
@@ -465,8 +467,8 @@ dependencies = [
 
 [[package]]
 name = "p3-matrix"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -479,16 +481,16 @@ dependencies = [
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "p3-mds"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "p3-dft",
  "p3-field",
@@ -499,8 +501,8 @@ dependencies = [
 
 [[package]]
 name = "p3-merkle-tree"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "itertools 0.14.0",
  "p3-commit",
@@ -517,8 +519,8 @@ dependencies = [
 
 [[package]]
 name = "p3-monty-31"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -540,8 +542,8 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon1"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "p3-field",
  "p3-symmetric",
@@ -550,8 +552,8 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -562,8 +564,8 @@ dependencies = [
 
 [[package]]
 name = "p3-symmetric"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -573,8 +575,8 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.5.0"
-source = "git+https://github.com/Plonky3/Plonky3?rev=e52636ec09663fd7d3bd4eaabb21dba8698f129a#e52636ec09663fd7d3bd4eaabb21dba8698f129a"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
 dependencies = [
  "serde",
  "transpose",
@@ -899,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -912,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -922,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -935,18 +937,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -958,7 +960,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -966,15 +968,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -986,68 +979,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "zerocopy"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "zerocopy-derive",
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+name = "zerocopy-derive"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,19 +11,19 @@ rust-version = "1.88"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 bincode = { version = "2", features = ["serde"] }
-p3-air = { git = "https://github.com/Plonky3/Plonky3", rev = "e52636ec09663fd7d3bd4eaabb21dba8698f129a" }
-p3-goldilocks = { git = "https://github.com/Plonky3/Plonky3", rev = "e52636ec09663fd7d3bd4eaabb21dba8698f129a" }
-p3-challenger = { git = "https://github.com/Plonky3/Plonky3", rev = "e52636ec09663fd7d3bd4eaabb21dba8698f129a" }
-p3-commit = { git = "https://github.com/Plonky3/Plonky3", rev = "e52636ec09663fd7d3bd4eaabb21dba8698f129a" }
-p3-dft = { git = "https://github.com/Plonky3/Plonky3", rev = "e52636ec09663fd7d3bd4eaabb21dba8698f129a" }
-p3-field = { git = "https://github.com/Plonky3/Plonky3", rev = "e52636ec09663fd7d3bd4eaabb21dba8698f129a" }
-p3-fri = { git = "https://github.com/Plonky3/Plonky3", rev = "e52636ec09663fd7d3bd4eaabb21dba8698f129a" }
-p3-keccak = { git = "https://github.com/Plonky3/Plonky3", rev = "e52636ec09663fd7d3bd4eaabb21dba8698f129a" }
-p3-matrix = { git = "https://github.com/Plonky3/Plonky3", rev = "e52636ec09663fd7d3bd4eaabb21dba8698f129a" }
-p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3", rev = "e52636ec09663fd7d3bd4eaabb21dba8698f129a" }
-p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3", rev = "e52636ec09663fd7d3bd4eaabb21dba8698f129a" }
-p3-symmetric = { git = "https://github.com/Plonky3/Plonky3", rev = "e52636ec09663fd7d3bd4eaabb21dba8698f129a" }
-p3-util = { git = "https://github.com/Plonky3/Plonky3", rev = "e52636ec09663fd7d3bd4eaabb21dba8698f129a" }
+p3-air = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b5dbb4413c69be63536efd64" }
+p3-goldilocks = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b5dbb4413c69be63536efd64" }
+p3-challenger = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b5dbb4413c69be63536efd64" }
+p3-commit = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b5dbb4413c69be63536efd64" }
+p3-dft = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b5dbb4413c69be63536efd64" }
+p3-field = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b5dbb4413c69be63536efd64" }
+p3-fri = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b5dbb4413c69be63536efd64" }
+p3-keccak = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b5dbb4413c69be63536efd64" }
+p3-matrix = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b5dbb4413c69be63536efd64" }
+p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b5dbb4413c69be63536efd64" }
+p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b5dbb4413c69be63536efd64" }
+p3-symmetric = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b5dbb4413c69be63536efd64" }
+p3-util = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b5dbb4413c69be63536efd64" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/src/builder/folder.rs
+++ b/src/builder/folder.rs
@@ -1,6 +1,6 @@
 /// Constraint folders for the prover and verifier, adapted from Plonky3.
 use p3_air::{AirBuilder, ExtensionBuilder, RowWindow};
-use p3_field::{BasedVectorSpace, PackedField};
+use p3_field::{Algebra, BasedVectorSpace};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 
@@ -92,7 +92,7 @@ impl<'a> AirBuilder for ProverConstraintFolder<'a> {
         self.accumulator += PackedExtVal::from_basis_coefficients_fn(|i| {
             let alpha_powers = &self.decomposed_alpha_powers[i]
                 [self.constraint_index..(self.constraint_index + N)];
-            PackedVal::packed_linear_combination::<N>(alpha_powers, &expr_array)
+            PackedVal::batched_linear_combination(&expr_array, alpha_powers)
         });
         self.constraint_index += N;
     }

--- a/src/builder/symbolic.rs
+++ b/src/builder/symbolic.rs
@@ -1,6 +1,6 @@
 /// Symbolic constraint builder and expressions, adapted from Plonky3.
 use p3_air::{Air, AirBuilder, ExtensionBuilder};
-use p3_field::{Algebra, Field, InjectiveMonomial, PrimeCharacteristicRing};
+use p3_field::{Algebra, Dup, Field, InjectiveMonomial, PrimeCharacteristicRing};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_util::log2_ceil_usize;
 use std::fmt::Debug;
@@ -173,6 +173,13 @@ impl<F: Field> SymbolicExpression<F> {
                 degree_multiple, ..
             } => *degree_multiple,
         }
+    }
+}
+
+impl<F: Field> Dup for SymbolicExpression<F> {
+    #[inline(always)]
+    fn dup(&self) -> Self {
+        self.clone()
     }
 }
 

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -29,6 +29,126 @@
 //!
 //! The resulting [`Proof`] can be serialized with [`Proof::to_bytes`] and deserialized
 //! with [`Proof::from_bytes`] for transport or storage.
+//!
+//! # Prover cost analysis
+//!
+//! The prover's computational work divides into polynomial commitments (FFT +
+//! Merkle hashing), lookup trace construction, constraint evaluation, and the
+//! FRI opening protocol. This section gives a concrete cost breakdown.
+//!
+//! ## Notation
+//!
+//! We use the following notation throughout:
+//! - C — number of circuits in the system
+//! - n_i — trace height (rows, power of two) of circuit i
+//! - w_i — stage 1 trace width (columns) of circuit i
+//! - p_i — preprocessed trace width of circuit i (0 if none)
+//! - L_i — number of lookups in circuit i
+//! - k_i — number of constraints in circuit i (after lookup expansion)
+//! - d_i — maximum constraint degree multiple of circuit i
+//! - q_i = next_pow2(max(d_i, 2) − 1) — quotient polynomial degree
+//! - D = 2 — extension field dimension (`BinomialExtensionField<Goldilocks, 2>`)
+//! - B = 2^log_blowup — FRI blowup factor
+//! - Q = num_queries — FRI query repetitions
+//! - a = max_log_arity — FRI folding arity (log₂)
+//!
+//! Derived quantities:
+//! - w2_i = 1 + L_i — stage 2 width in extension field elements
+//! - W_i = w_i + w2_i · D + q_i · D — total committed width per circuit (base field)
+//! - H = max_i(n_i) · B — largest LDE height
+//! - R = ⌈(log₂ H − log_final_poly_len) / a⌉ — FRI folding rounds
+//!
+//! ## Stage 1 commit
+//!
+//! Each circuit's main trace (n_i × w_i) undergoes a coset LDE (FFT-based)
+//! expanding from n_i to n_i · B evaluations, followed by Merkle tree
+//! construction over the LDE rows. All circuits are committed together.
+//!
+//! ```text
+//! FFT work:   Σ_i  w_i · n_i · B · log₂(n_i · B)   field multiplications
+//! Hashing:    Σ_i  n_i · B                            Merkle leaf hashes
+//! ```
+//!
+//! ## Lookup trace construction
+//!
+//! For each circuit with L_i > 0 lookups, the prover computes per-row
+//! fingerprints (Horner evaluations in the extension field), batch-inverts
+//! all messages via Montgomery's trick (≈ 3 extension multiplications per
+//! element), and builds the running accumulator.
+//!
+//! ```text
+//! Fingerprints:  Σ_i  n_i · L_i · |args|   extension field multiplications
+//! Inversions:    Σ_i  3 · n_i · L_i         extension field multiplications
+//! Accumulator:   Σ_i  n_i · L_i             extension field multiply-adds
+//! ```
+//!
+//! ## Stage 2 commit
+//!
+//! Stage 2 traces (n_i × w2_i extension elements, flattened to
+//! n_i × w2_i · D base elements) are committed identically to stage 1.
+//!
+//! ```text
+//! FFT work:   Σ_i  w2_i · D · n_i · B · log₂(n_i · B)   field multiplications
+//! Hashing:    Σ_i  n_i · B                                 Merkle leaf hashes
+//! ```
+//!
+//! ## Quotient computation and commit
+//!
+//! For each circuit, the prover evaluates all k_i constraints at every point
+//! of the quotient domain (size n_i · q_i) and divides by the vanishing
+//! polynomial. If q_i ≤ B, the trace evaluations on the quotient domain are
+//! obtained by subsetting the LDE (essentially free); otherwise an additional
+//! iFFT + FFT is required.
+//!
+//! The quotient polynomial is split into q_i sub-polynomials (each of degree
+//! n_i) and committed.
+//!
+//! ```text
+//! Constraint eval:  Σ_i  n_i · q_i · eval_cost(k_i)         field operations
+//! Quotient FFT:     Σ_i  q_i · D · n_i · B · log₂(n_i · B)  field multiplications
+//! Hashing:          Σ_i  q_i · n_i · B                        Merkle leaf hashes
+//! ```
+//!
+//! Here eval_cost(k_i) denotes the per-row cost of evaluating all k_i folded
+//! constraints, which depends on the specific AIR.
+//!
+//! ## FRI opening
+//!
+//! All polynomials (stage 1, stage 2, quotient, and preprocessed if present)
+//! are opened at ζ and ζ·g via barycentric interpolation, then verified
+//! through FRI. The preprocessed traces' LDE was computed at setup time
+//! ([`System::new`]); only their opening contributes to per-proof cost.
+//!
+//! ```text
+//! Interpolation:  Σ_i  n_i · B · W_i     field multiply-adds (barycentric)
+//! FRI folding:    ≈ H · 2^a / (2^a − 1)  extension field operations
+//! FRI queries:    Q · R · log₂ H          hash operations (Merkle paths)
+//! FRI grinding:   2^pow_commit · R + 2^pow_query   hash invocations
+//! ```
+//!
+//! ## Overall cost
+//!
+//! The total per-proof cost is approximately:
+//!
+//! ```text
+//! C_prove  ≈  Σ_i  n_i · B · log₂(n_i · B) · W_i     (FFT — all commit rounds)
+//!           + Σ_i  n_i · q_i · eval_cost(k_i)          (constraint evaluation)
+//!           + Σ_i  n_i · B · W_i                        (barycentric interpolation)
+//!           + Q · R · log₂ H                            (FRI query phase)
+//!           + 2^pow_commit · R + 2^pow_query            (FRI grinding)
+//! ```
+//!
+//! For typical parameters (B = 2, Q = 100, a = 1):
+//! - **FFT dominates** when traces have large n_i · W_i products.
+//! - **Constraint evaluation** can dominate for circuits with many complex
+//!   constraints (large k_i) or high quotient degree (large q_i).
+//! - **FRI queries** grow logarithmically in trace height but linearly in Q.
+//! - **Lookup computation** is subdominant unless L_i is very large.
+//! - **Grinding** is a constant overhead per FRI round (or once for queries).
+//!
+//! Cost scales **linearly** in trace height n_i for fixed circuit structure,
+//! with a logarithmic factor from the FFT. Doubling n_i approximately doubles
+//! the prover's work.
 
 use std::ops::Deref;
 
@@ -132,7 +252,8 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a>>> System<A> {
         let pcs = config.pcs();
         let mut challenger = config.initialise_challenger();
 
-        // commit to stage 1 traces
+        // Cost: "Stage 1 commit" — coset LDE (FFT) of each trace from n_i to
+        // n_i·B rows, then Merkle tree. FFT work: Σ w_i · n_i · B · log₂(n_i·B).
         let mut log_degrees = vec![];
         let evaluations = witness.traces.into_iter().map(|trace| {
             let degree = trace.height();
@@ -176,13 +297,16 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a>>> System<A> {
             acc += message.inverse();
         }
 
-        // commit to stage 2 traces
+        // Cost: "Lookup trace construction" — fingerprint (Horner), batch
+        // inversion, and accumulator update. Total: Σ n_i·L_i extension field ops.
         let (stage_2_traces, intermediate_accumulators) = Lookup::stage_2_traces(
             &witness.lookups,
             lookup_argument_challenge,
             &fingerprint_challenge,
             acc,
         );
+        // Cost: "Stage 2 commit" — LDE + Merkle for flattened extension traces.
+        // FFT work: Σ w2_i · D · n_i · B · log₂(n_i·B).
         let evaluations = stage_2_traces.into_iter().map(|trace| {
             let degree = trace.height();
             let trace_domain =
@@ -196,7 +320,9 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a>>> System<A> {
         // generate constraint challenge
         let constraint_challenge: ExtVal = challenger.sample_algebra_element();
 
-        // commit to evaluations of the quotient polynomials
+        // Cost: "Quotient computation and commit" — constraint evaluation on the
+        // quotient domain (Σ n_i·q_i·eval_cost(k_i)) plus LDE + Merkle of the
+        // quotient sub-polynomials (Σ q_i·D·n_i·B·log₂(n_i·B)).
         debug_assert_eq!(intermediate_accumulators.len(), self.circuits.len());
         debug_assert_eq!(log_degrees.len(), self.circuits.len());
         let mut quotient_degrees = vec![];
@@ -289,7 +415,8 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a>>> System<A> {
             quotient_chunks: quotient_commit,
         };
 
-        // generate the out of domain point and prove polynomial evaluations
+        // Cost: "FRI opening" — barycentric interpolation (Σ n_i·B·W_i),
+        // FRI folding (≈ H), and FRI queries (Q·R·log₂ H hash ops).
         let zeta: ExtVal = challenger.sample_algebra_element();
         let mut round0_openings = vec![];
         let mut round1_openings = vec![];


### PR DESCRIPTION
- Bump Plonky3 dependency from `e52636ec` to `e9d75614` and adapt to breaking API changes:
  - Implement `Dup` trait for `SymbolicExpression<F>` (new bound on `PrimeCharacteristicRing`)
  - Rename `packed_linear_combination` → `batched_linear_combination` with updated signature
  - Fix imports: add `Algebra` + `Dup`, remove unused `PackedField`
- Add a comprehensive prover cost analysis to the `prover` module docstring, covering all five proving phases (stage 1 commit, lookup trace construction, stage 2 commit, quotient computation/commit, FRI opening) with notation, concrete formulas, and dominant-term analysis
- Add inline cost annotations at each key step in `prove_multiple_claims`