### PR TITLE
Generic config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +129,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "criterion"
@@ -191,6 +211,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core",
+]
 
 [[package]]
 name = "half"
@@ -282,6 +314,7 @@ dependencies = [
  "bincode",
  "criterion",
  "p3-air",
+ "p3-baby-bear",
  "p3-challenger",
  "p3-commit",
  "p3-dft",
@@ -294,6 +327,7 @@ dependencies = [
  "p3-merkle-tree",
  "p3-symmetric",
  "p3-util",
+ "rand",
  "serde",
  "tracing",
 ]
@@ -346,6 +380,21 @@ dependencies = [
  "p3-field",
  "p3-matrix",
  "tracing",
+]
+
+[[package]]
+name = "p3-baby-bear"
+version = "0.5.1"
+source = "git+https://github.com/Plonky3/Plonky3?rev=e9d75614dd6816f9b5dbb4413c69be63536efd64#e9d75614dd6816f9b5dbb4413c69be63536efd64"
+dependencies = [
+ "p3-challenger",
+ "p3-field",
+ "p3-mds",
+ "p3-monty-31",
+ "p3-poseidon1",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "rand",
 ]
 
 [[package]]
@@ -642,11 +691,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
+ "chacha20",
+ "getrandom",
  "rand_core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -698,9 +698,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 authors = ["Argument Engineering <engineering@argument.xyz>"]
 license = "MIT OR Apache-2.0"
-rust-version = "1.88"
+rust-version = "1.91"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -28,6 +28,8 @@ p3-util = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b
 
 [dev-dependencies]
 criterion = "0.5"
+p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b5dbb4413c69be63536efd64" }
+rand = "0.10"
 
 [[bench]]
 name = "multi_stark"

--- a/README.md
+++ b/README.md
@@ -12,10 +12,17 @@ lookup arguments for shared state.
 - **Lookup arguments** — push/pull interactions of arbitrary length between
   circuits, enforced via accumulator-based multiset checks
 - **Preprocessed tables** — commit to fixed tables once, reuse across proofs
+- **Generic over field, hash, and PCS** — the protocol is parameterized by a
+  `StarkGenericConfig` (base field via the PCS, challenge field, challenger);
+  a batteries-included Goldilocks/Keccak instantiation is provided
 - **Serialization** — `Proof::to_bytes` / `Proof::from_bytes` via bincode
 - **Parallel proving** — opt-in via the `parallel` feature flag
 
-## Cryptographic setup
+## Reference configuration
+
+The protocol (`system`, `prover`, `verifier` modules) is generic over
+[`StarkGenericConfig`](src/config.rs). The crate ships one production
+configuration, `GoldilocksKeccakConfig` in [`types`](src/types.rs):
 
 | Component | Choice                                        |
 |-----------|-----------------------------------------------|
@@ -23,6 +30,12 @@ lookup arguments for shared state.
 | Extension | Degree-2 binomial extension (~2^128 elements) |
 | Hash      | Keccak-256                                    |
 | PCS       | FRI over Merkle trees                         |
+
+A second instantiation (BabyBear field, degree-4 extension, Poseidon2
+hashing) lives in the test suite to keep the protocol honest about its
+genericity. When writing your own configuration, pick a challenge field
+large enough for the target security level — the Schwartz-Zippel terms of
+the soundness error scale with 1/|challenge field|.
 
 Security level is configurable via `FriParameters`. With `log_blowup = 1` and
 `num_queries = 100`, FRI provides ~2^(-100) *conjectured* soundness error

--- a/README.md
+++ b/README.md
@@ -25,8 +25,14 @@ lookup arguments for shared state.
 | PCS       | FRI over Merkle trees                         |
 
 Security level is configurable via `FriParameters`. With `log_blowup = 1` and
-`num_queries = 100`, FRI provides ~2^(-100) soundness error. See the
+`num_queries = 100`, FRI provides ~2^(-100) *conjectured* soundness error
+(~2^(-50) under the proven Johnson bound). See the
 [verifier module docs](src/verifier.rs) for the full soundness argument.
+
+> :warning: **Not zero-knowledge.** Proofs are succinct arguments of
+> knowledge, but traces are committed without blinding — FRI query responses
+> reveal witness data. Do not use this when the witness must remain hidden
+> from the verifier.
 
 ## Examples
 

--- a/benches/multi_stark.rs
+++ b/benches/multi_stark.rs
@@ -127,7 +127,10 @@ impl U32CS {
 // Witness generation
 // ---------------------------------------------------------------------------
 
-fn build_witness(num_adds: usize, system: &System<U32CS>) -> SystemWitness {
+fn build_witness(
+    num_adds: usize,
+    system: &System<GoldilocksKeccakConfig, U32CS>,
+) -> SystemWitness<Val> {
     let byte_width = 1;
     let add_width = 14;
     let add_height = num_adds.next_power_of_two();

--- a/benches/multi_stark.rs
+++ b/benches/multi_stark.rs
@@ -16,7 +16,7 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use multi_stark::builder::symbolic::{SymbolicExpression, preprocessed_var, var};
 use multi_stark::lookup::{Lookup, LookupAir};
 use multi_stark::system::{System, SystemWitness};
-use multi_stark::types::{CommitmentParameters, FriParameters, Val};
+use multi_stark::types::{CommitmentParameters, FriParameters, GoldilocksKeccakConfig, Val};
 use multi_stark::{
     p3_air::{Air, AirBuilder, BaseAir, WindowAccess},
     p3_field::{Field, PrimeCharacteristicRing},
@@ -201,20 +201,22 @@ fn build_claims(num_adds: usize) -> Vec<[Val; 4]> {
 // ---------------------------------------------------------------------------
 
 fn bench_prove(c: &mut Criterion) {
-    let commitment_parameters = CommitmentParameters {
-        log_blowup: 1,
-        cap_height: 0,
-    };
+    let config = GoldilocksKeccakConfig::new(
+        CommitmentParameters {
+            log_blowup: 1,
+            cap_height: 0,
+        },
+        FriParameters {
+            log_final_poly_len: 0,
+            max_log_arity: 1,
+            num_queries: 100,
+            commit_proof_of_work_bits: 10,
+            query_proof_of_work_bits: 10,
+        },
+    );
     let byte_table = LookupAir::new(U32CS::ByteTable, U32CS::ByteTable.lookups());
     let u32_add = LookupAir::new(U32CS::U32Add, U32CS::U32Add.lookups());
-    let (system, key) = System::new(commitment_parameters, [byte_table, u32_add]);
-    let fri_parameters = FriParameters {
-        log_final_poly_len: 0,
-        max_log_arity: 1,
-        num_queries: 100,
-        commit_proof_of_work_bits: 10,
-        query_proof_of_work_bits: 10,
-    };
+    let (system, key) = System::new(config, [byte_table, u32_add]);
 
     let mut group = c.benchmark_group("prove");
     group.sample_size(10);
@@ -229,9 +231,7 @@ fn bench_prove(c: &mut Criterion) {
             |b| {
                 b.iter_batched(
                     || build_witness(num_adds, &system),
-                    |witness| {
-                        system.prove_multiple_claims(fri_parameters, &key, &claim_refs, witness)
-                    },
+                    |witness| system.prove_multiple_claims(&key, &claim_refs, witness),
                     criterion::BatchSize::LargeInput,
                 );
             },
@@ -241,20 +241,22 @@ fn bench_prove(c: &mut Criterion) {
 }
 
 fn bench_verify(c: &mut Criterion) {
-    let commitment_parameters = CommitmentParameters {
-        log_blowup: 1,
-        cap_height: 0,
-    };
+    let config = GoldilocksKeccakConfig::new(
+        CommitmentParameters {
+            log_blowup: 1,
+            cap_height: 0,
+        },
+        FriParameters {
+            log_final_poly_len: 0,
+            max_log_arity: 1,
+            num_queries: 100,
+            commit_proof_of_work_bits: 10,
+            query_proof_of_work_bits: 10,
+        },
+    );
     let byte_table = LookupAir::new(U32CS::ByteTable, U32CS::ByteTable.lookups());
     let u32_add = LookupAir::new(U32CS::U32Add, U32CS::U32Add.lookups());
-    let (system, key) = System::new(commitment_parameters, [byte_table, u32_add]);
-    let fri_parameters = FriParameters {
-        log_final_poly_len: 0,
-        max_log_arity: 1,
-        num_queries: 100,
-        commit_proof_of_work_bits: 10,
-        query_proof_of_work_bits: 10,
-    };
+    let (system, key) = System::new(config, [byte_table, u32_add]);
 
     let mut group = c.benchmark_group("verify");
     group.sample_size(10);
@@ -265,15 +267,11 @@ fn bench_verify(c: &mut Criterion) {
         let claims = build_claims(num_adds);
         let claim_refs: Vec<&[Val]> = claims.iter().map(|c| c.as_slice()).collect();
         let witness = build_witness(num_adds, &system);
-        let proof = system.prove_multiple_claims(fri_parameters, &key, &claim_refs, witness);
+        let proof = system.prove_multiple_claims(&key, &claim_refs, witness);
         group.bench_function(
             BenchmarkId::new("u32_add", format!("2^{log_height}")),
             |b| {
-                b.iter(|| {
-                    system
-                        .verify_multiple_claims(fri_parameters, &claim_refs, &proof)
-                        .unwrap()
-                });
+                b.iter(|| system.verify_multiple_claims(&claim_refs, &proof).unwrap());
             },
         );
     }

--- a/examples/lookup_proof.rs
+++ b/examples/lookup_proof.rs
@@ -15,7 +15,7 @@
 use multi_stark::builder::symbolic::{SymbolicExpression, var};
 use multi_stark::lookup::{Lookup, LookupAir};
 use multi_stark::system::{System, SystemWitness};
-use multi_stark::types::{CommitmentParameters, FriParameters, Val};
+use multi_stark::types::{CommitmentParameters, FriParameters, GoldilocksKeccakConfig, Val};
 use multi_stark::{
     p3_air::{Air, AirBuilder, BaseAir, WindowAccess},
     p3_field::{Field, PrimeCharacteristicRing},
@@ -103,14 +103,23 @@ where
 }
 
 fn main() {
-    let commitment_parameters = CommitmentParameters {
-        log_blowup: 1,
-        cap_height: 0,
-    };
+    let config = GoldilocksKeccakConfig::new(
+        CommitmentParameters {
+            log_blowup: 1,
+            cap_height: 0,
+        },
+        FriParameters {
+            log_final_poly_len: 0,
+            max_log_arity: 1,
+            num_queries: 64,
+            commit_proof_of_work_bits: 0,
+            query_proof_of_work_bits: 0,
+        },
+    );
 
     let even = LookupAir::new(ParityAir::Even, ParityAir::Even.lookups());
     let odd = LookupAir::new(ParityAir::Odd, ParityAir::Odd.lookups());
-    let (system, key) = System::new(commitment_parameters, [even, odd]);
+    let (system, key) = System::new(config, [even, odd]);
 
     let f = Val::from_u32;
     #[rustfmt::skip]
@@ -142,16 +151,9 @@ fn main() {
 
     // Claim: [even_index=0, input=4, expected_output=1] — is_even(4) should be 1
     let claim = &[f(0), f(4), f(1)];
-    let fri_parameters = FriParameters {
-        log_final_poly_len: 0,
-        max_log_arity: 1,
-        num_queries: 64,
-        commit_proof_of_work_bits: 0,
-        query_proof_of_work_bits: 0,
-    };
 
-    let proof = system.prove(fri_parameters, &key, claim, witness);
-    system.verify(fri_parameters, claim, &proof).unwrap();
+    let proof = system.prove(&key, claim, witness);
+    system.verify(claim, &proof).unwrap();
     println!("Lookup proof verified successfully!");
 
     let bytes = proof.to_bytes().expect("serialization failed");

--- a/examples/pcs_example.rs
+++ b/examples/pcs_example.rs
@@ -1,0 +1,121 @@
+//! Polynomial commitment scheme (PCS) using FRI over the Goldilocks field.
+//!
+//! Shows the three core PCS operations in sequence:
+//!   - **Commit**: LDE + Merkle tree over polynomial evaluations.
+//!   - **Open**: FRI opening proof for evaluation at a challenge point.
+//!   - **Verify**: check the opening against the committed polynomials.
+//!
+//! All types (`Val`, `ExtVal`, `Pcs`, `Challenger`, ...) come from
+//! [`multi_stark::types`], which bundles the concrete FRI/Goldilocks/Keccak
+//! instantiation used by the STARK prover.
+//!
+//! Run with:
+//! ```sh
+//! cargo run --example pcs_example --release
+//! ```
+
+use bincode::{config::standard, serde::encode_to_vec};
+use multi_stark::types::{
+    Challenger, Commitment, CommitmentParameters, Domain, ExtVal, FriParameters, Pcs, PcsProof,
+    ProverData, StarkConfig, Val,
+};
+use p3_challenger::{CanObserve, FieldChallenger};
+use p3_commit::{OpenedValues, Pcs as PcsTrait};
+use p3_field::PrimeCharacteristicRing;
+use p3_matrix::dense::RowMajorMatrix;
+
+fn main() {
+    // ── Parameters ──────────────────────────────────────────────────────────
+    // log_blowup = 1 → blowup factor 2 (minimal Reed-Solomon rate).
+    // num_queries = 100 → ~100 bits of conjectured FRI soundness at rate 1/2
+    // (~50 bits under the proven Johnson bound).
+    let commitment_params = CommitmentParameters {
+        log_blowup: 1,
+        cap_height: 0,
+    };
+    let fri_params = FriParameters {
+        log_final_poly_len: 0,
+        max_log_arity: 1,
+        num_queries: 100,
+        commit_proof_of_work_bits: 0,
+        query_proof_of_work_bits: 0,
+    };
+
+    let config = StarkConfig::new(commitment_params, fri_params);
+    let pcs = config.pcs();
+
+    // ── Build polynomial evaluations ─────────────────────────────────────────
+    // Commit 4 polynomials over a domain of size 32 (degree ≤ 31).
+    // The evaluation matrix has one column per polynomial.
+    let log_degree: u32 = 5; // domain size = 2^5 = 32
+    let degree = 1usize << log_degree;
+    let num_polys: usize = 1;
+
+    let domain: Domain =
+        <Pcs as PcsTrait<ExtVal, Challenger>>::natural_domain_for_degree(pcs, degree);
+
+    // Simple non-trivial evaluations: entry (i, j) = i * num_polys + j.
+    let n = u32::try_from(degree * num_polys).unwrap();
+    let matrix = RowMajorMatrix::new((0..n).map(Val::from_u32).collect::<Vec<_>>(), num_polys);
+
+    // ── Commit ───────────────────────────────────────────────────────────────
+    // The PCS computes a coset LDE (blowup × domain size evaluations), then
+    // builds a Merkle tree over the extended rows. The root is the commitment.
+    let (commitment, prover_data): (Commitment, ProverData) =
+        <Pcs as PcsTrait<ExtVal, Challenger>>::commit(pcs, [(domain, matrix)]);
+    println!(
+        "Committed {} polynomials over domain of size {} (degree ≤ {})",
+        num_polys,
+        degree,
+        degree - 1
+    );
+
+    // ── Open ─────────────────────────────────────────────────────────────────
+    // Fiat-Shamir: observe the commitment, then sample a challenge point ζ
+    // in the degree-2 extension field ExtVal = Goldilocks².
+    let mut prover_challenger: Challenger = config.initialise_challenger();
+    prover_challenger.observe(commitment.clone());
+    let zeta: ExtVal = prover_challenger.sample_algebra_element();
+    let num_open = 2;
+
+    // Open all polynomials at ζ and produce a FRI opening proof.
+    // Input: for each committed batch, a list of opening-point vectors (one per matrix).
+    // Output: claimed evaluations + proof.
+    let (opened_values, pcs_proof): (OpenedValues<_>, PcsProof) =
+        <Pcs as PcsTrait<ExtVal, Challenger>>::open(
+            pcs,
+            vec![(&prover_data, vec![vec![zeta; num_open]])],
+            &mut prover_challenger,
+        );
+    // opened_values[round][matrix_idx][point_idx] = Vec<ExtVal> (one per column)
+    let evals_at_zeta = opened_values[0][0][0].clone();
+    println!("Opened at ζ: {} polynomial values", evals_at_zeta.len());
+
+    // ── Proof size ───────────────────────────────────────────────────────────
+    let opened_values_bytes =
+        encode_to_vec(&opened_values, standard()).expect("serialization failed");
+    println!("opened_values size: {} bytes", opened_values_bytes.len());
+    let proof_bytes = encode_to_vec(&pcs_proof, standard()).expect("serialization failed");
+    println!("PCS proof size: {} bytes", proof_bytes.len());
+
+    // ── Verify ───────────────────────────────────────────────────────────────
+    // The verifier mirrors the prover's Fiat-Shamir transcript (observe commitment,
+    // resample ζ), then checks the opening proof against the claimed evaluations.
+    let mut verifier_challenger: Challenger = config.initialise_challenger();
+    verifier_challenger.observe(commitment.clone());
+    let verifier_zeta: ExtVal = verifier_challenger.sample_algebra_element();
+    assert_eq!(verifier_zeta, zeta, "Fiat-Shamir transcript mismatch");
+
+    <Pcs as PcsTrait<ExtVal, Challenger>>::verify(
+        pcs,
+        vec![(
+            commitment,
+            vec![(domain, vec![(zeta, evals_at_zeta); num_open])],
+        )],
+        &pcs_proof,
+        &mut verifier_challenger,
+    )
+    .expect("PCS verification failed");
+
+    println!("PCS proof verified successfully!");
+}

--- a/examples/pcs_example.rs
+++ b/examples/pcs_example.rs
@@ -46,7 +46,7 @@ fn main() {
     let pcs = config.pcs();
 
     // ── Build polynomial evaluations ─────────────────────────────────────────
-    // Commit 4 polynomials over a domain of size 32 (degree ≤ 31).
+    // Commit `num_polys` polynomials over a domain of size 32 (degree ≤ 31).
     // The evaluation matrix has one column per polynomial.
     let log_degree: u32 = 5; // domain size = 2^5 = 32
     let degree = 1usize << log_degree;

--- a/examples/pcs_example.rs
+++ b/examples/pcs_example.rs
@@ -15,9 +15,10 @@
 //! ```
 
 use bincode::{config::standard, serde::encode_to_vec};
+use multi_stark::config::StarkGenericConfig;
 use multi_stark::types::{
-    Challenger, Commitment, CommitmentParameters, Domain, ExtVal, FriParameters, Pcs, PcsProof,
-    ProverData, StarkConfig, Val,
+    Challenger, Commitment, CommitmentParameters, Domain, ExtVal, FriParameters,
+    GoldilocksKeccakConfig, Pcs, PcsProof, ProverData, Val,
 };
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{OpenedValues, Pcs as PcsTrait};
@@ -41,7 +42,7 @@ fn main() {
         query_proof_of_work_bits: 0,
     };
 
-    let config = StarkConfig::new(commitment_params, fri_params);
+    let config = GoldilocksKeccakConfig::new(commitment_params, fri_params);
     let pcs = config.pcs();
 
     // ── Build polynomial evaluations ─────────────────────────────────────────

--- a/examples/preprocessed_proof.rs
+++ b/examples/preprocessed_proof.rs
@@ -14,7 +14,7 @@
 use multi_stark::builder::symbolic::{SymbolicExpression, preprocessed_var, var};
 use multi_stark::lookup::{Lookup, LookupAir};
 use multi_stark::system::{System, SystemWitness};
-use multi_stark::types::{CommitmentParameters, FriParameters, Val};
+use multi_stark::types::{CommitmentParameters, FriParameters, GoldilocksKeccakConfig, Val};
 use multi_stark::{
     p3_air::{Air, AirBuilder, BaseAir, WindowAccess},
     p3_field::{Field, PrimeCharacteristicRing},
@@ -87,14 +87,23 @@ impl SquaresCS {
 }
 
 fn main() {
-    let commitment_parameters = CommitmentParameters {
-        log_blowup: 1,
-        cap_height: 0,
-    };
+    let config = GoldilocksKeccakConfig::new(
+        CommitmentParameters {
+            log_blowup: 1,
+            cap_height: 0,
+        },
+        FriParameters {
+            log_final_poly_len: 0,
+            max_log_arity: 1,
+            num_queries: 64,
+            commit_proof_of_work_bits: 0,
+            query_proof_of_work_bits: 0,
+        },
+    );
 
     let range_table = LookupAir::new(SquaresCS::RangeTable, SquaresCS::RangeTable.lookups());
     let squares = LookupAir::new(SquaresCS::Squares, SquaresCS::Squares.lookups());
-    let (system, key) = System::new(commitment_parameters, [range_table, squares]);
+    let (system, key) = System::new(config, [range_table, squares]);
 
     // Build traces: square every value 0..16
     let n = 16u32;
@@ -117,19 +126,9 @@ fn main() {
     let squares_trace = RowMajorMatrix::new(sq_values, 5);
     let witness = SystemWitness::from_stage_1(vec![range_trace, squares_trace], &system);
 
-    let fri_parameters = FriParameters {
-        log_final_poly_len: 0,
-        max_log_arity: 1,
-        num_queries: 64,
-        commit_proof_of_work_bits: 0,
-        query_proof_of_work_bits: 0,
-    };
-
     let no_claims: &[&[Val]] = &[];
-    let proof = system.prove_multiple_claims(fri_parameters, &key, no_claims, witness);
-    system
-        .verify_multiple_claims(fri_parameters, no_claims, &proof)
-        .unwrap();
+    let proof = system.prove_multiple_claims(&key, no_claims, witness);
+    system.verify_multiple_claims(no_claims, &proof).unwrap();
     println!("Preprocessed proof verified successfully!");
 
     let bytes = proof.to_bytes().expect("serialization failed");

--- a/examples/simple_proof.rs
+++ b/examples/simple_proof.rs
@@ -11,7 +11,7 @@
 
 use multi_stark::lookup::LookupAir;
 use multi_stark::system::{System, SystemWitness};
-use multi_stark::types::{CommitmentParameters, FriParameters, Val};
+use multi_stark::types::{CommitmentParameters, FriParameters, GoldilocksKeccakConfig, Val};
 use multi_stark::{
     p3_air::{Air, AirBuilder, BaseAir, WindowAccess},
     p3_field::PrimeCharacteristicRing,
@@ -44,14 +44,23 @@ where
 }
 
 fn main() {
-    let commitment_parameters = CommitmentParameters {
-        log_blowup: 1,
-        cap_height: 0,
-    };
+    let config = GoldilocksKeccakConfig::new(
+        CommitmentParameters {
+            log_blowup: 1,
+            cap_height: 0,
+        },
+        FriParameters {
+            log_final_poly_len: 0,
+            max_log_arity: 1,
+            num_queries: 64,
+            commit_proof_of_work_bits: 0,
+            query_proof_of_work_bits: 0,
+        },
+    );
 
     // Wrap the AIR with empty lookups
     let air = LookupAir::new(PythagoreanAir, vec![]);
-    let (system, key) = System::new(commitment_parameters, [air]);
+    let (system, key) = System::new(config, [air]);
 
     // Build a trace with 4 rows of Pythagorean triples
     let f = Val::from_u32;
@@ -74,22 +83,12 @@ fn main() {
     );
     let witness = SystemWitness::from_stage_1(vec![trace], &system);
 
-    let fri_parameters = FriParameters {
-        log_final_poly_len: 0,
-        max_log_arity: 1,
-        num_queries: 64,
-        commit_proof_of_work_bits: 0,
-        query_proof_of_work_bits: 0,
-    };
-
     // Prove
     let no_claims = &[];
-    let proof = system.prove_multiple_claims(fri_parameters, &key, no_claims, witness);
+    let proof = system.prove_multiple_claims(&key, no_claims, witness);
 
     // Verify
-    system
-        .verify_multiple_claims(fri_parameters, no_claims, &proof)
-        .unwrap();
+    system.verify_multiple_claims(no_claims, &proof).unwrap();
     println!("Proof verified successfully!");
 
     // Show proof size

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 profile = "default"
-channel = "1.88"
+channel = "1.91"

--- a/src/builder/check.rs
+++ b/src/builder/check.rs
@@ -1,22 +1,23 @@
 use p3_air::{Air, AirBuilder, ExtensionBuilder, RowWindow};
-use p3_field::PrimeCharacteristicRing;
 use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
 use p3_matrix::stack::VerticalPair;
 
-use crate::types::{ExtVal, Val};
+use p3_field::{ExtensionField, Field};
 
 use super::TwoStagedBuilder;
 
-pub fn check_constraints<A>(
+pub fn check_constraints<F, EF, A>(
     air: &A,
-    preprocessed: Option<&RowMajorMatrix<Val>>,
-    stage_1: &RowMajorMatrix<Val>,
-    stage_2: &RowMajorMatrix<ExtVal>,
-    public_values: &[Val],
-    stage_2_public_values: &[ExtVal],
+    preprocessed: Option<&RowMajorMatrix<F>>,
+    stage_1: &RowMajorMatrix<F>,
+    stage_2: &RowMajorMatrix<EF>,
+    public_values: &[F],
+    stage_2_public_values: &[EF],
 ) where
-    A: for<'a> Air<DebugConstraintBuilder<'a>>,
+    F: Field,
+    EF: ExtensionField<F>,
+    A: for<'a> Air<DebugConstraintBuilder<'a, F, EF>>,
 {
     let height = stage_1.height();
 
@@ -43,9 +44,9 @@ pub fn check_constraints<A>(
             stage_2,
             public_values,
             stage_2_public_values,
-            is_first_row: Val::from_bool(i == 0),
-            is_last_row: Val::from_bool(i == height - 1),
-            is_transition: Val::from_bool(i != height - 1),
+            is_first_row: F::from_bool(i == 0),
+            is_last_row: F::from_bool(i == height - 1),
+            is_transition: F::from_bool(i != height - 1),
         };
         // We must call `eval` on the same block as the `preprocessed` matrix view, otherwise the borrow checker will complain.
         // Mutation is used to remove code duplication.
@@ -62,31 +63,31 @@ pub fn check_constraints<A>(
 }
 
 #[derive(Debug)]
-pub struct DebugConstraintBuilder<'a> {
+pub struct DebugConstraintBuilder<'a, F: Field, EF: ExtensionField<F>> {
     /// The index of the row currently being evaluated.
     row_index: usize,
     /// A two-row window over the preprocessed trace (current and next row).
-    preprocessed: RowWindow<'a, Val>,
-    stage_1: VerticalPair<RowMajorMatrixView<'a, Val>, RowMajorMatrixView<'a, Val>>,
-    stage_2: VerticalPair<RowMajorMatrixView<'a, ExtVal>, RowMajorMatrixView<'a, ExtVal>>,
+    preprocessed: RowWindow<'a, F>,
+    stage_1: VerticalPair<RowMajorMatrixView<'a, F>, RowMajorMatrixView<'a, F>>,
+    stage_2: VerticalPair<RowMajorMatrixView<'a, EF>, RowMajorMatrixView<'a, EF>>,
     /// The public values provided for constraint validation (e.g. inputs or outputs).
-    public_values: &'a [Val],
-    stage_2_public_values: &'a [ExtVal],
+    public_values: &'a [F],
+    stage_2_public_values: &'a [EF],
     /// A flag indicating whether this is the first row.
-    is_first_row: Val,
+    is_first_row: F,
     /// A flag indicating whether this is the last row.
-    is_last_row: Val,
+    is_last_row: F,
     /// A flag indicating whether this is a transition row (not the last row).
-    is_transition: Val,
+    is_transition: F,
 }
 
-impl<'a> AirBuilder for DebugConstraintBuilder<'a> {
-    type F = Val;
-    type Expr = Val;
-    type Var = Val;
-    type PreprocessedWindow = RowWindow<'a, Val>;
-    type MainWindow = RowWindow<'a, Val>;
-    type PublicVar = Val;
+impl<'a, F: Field, EF: ExtensionField<F>> AirBuilder for DebugConstraintBuilder<'a, F, EF> {
+    type F = F;
+    type Expr = F;
+    type Var = F;
+    type PreprocessedWindow = RowWindow<'a, F>;
+    type MainWindow = RowWindow<'a, F>;
+    type PublicVar = F;
 
     fn main(&self) -> Self::MainWindow {
         RowWindow::from_two_rows(self.stage_1.top.values, self.stage_1.bottom.values)
@@ -117,7 +118,7 @@ impl<'a> AirBuilder for DebugConstraintBuilder<'a> {
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
         assert_eq!(
             x.into(),
-            Val::ZERO,
+            F::ZERO,
             "constraints had nonzero value on row {}",
             self.row_index
         );
@@ -138,10 +139,10 @@ impl<'a> AirBuilder for DebugConstraintBuilder<'a> {
     }
 }
 
-impl<'a> ExtensionBuilder for DebugConstraintBuilder<'a> {
-    type EF = ExtVal;
-    type ExprEF = ExtVal;
-    type VarEF = ExtVal;
+impl<F: Field, EF: ExtensionField<F>> ExtensionBuilder for DebugConstraintBuilder<'_, F, EF> {
+    type EF = EF;
+    type ExprEF = EF;
+    type VarEF = EF;
 
     /// Assert that an extension field expression is zero.
     fn assert_zero_ext<I>(&mut self, x: I)
@@ -151,7 +152,7 @@ impl<'a> ExtensionBuilder for DebugConstraintBuilder<'a> {
         let x = x.into();
         assert_eq!(
             x,
-            ExtVal::ZERO,
+            EF::ZERO,
             "constraints had nonzero value on row {}",
             self.row_index
         );
@@ -172,8 +173,8 @@ impl<'a> ExtensionBuilder for DebugConstraintBuilder<'a> {
     }
 }
 
-impl<'a> TwoStagedBuilder for DebugConstraintBuilder<'a> {
-    type MP = VerticalPair<RowMajorMatrixView<'a, ExtVal>, RowMajorMatrixView<'a, ExtVal>>;
+impl<'a, F: Field, EF: ExtensionField<F>> TwoStagedBuilder for DebugConstraintBuilder<'a, F, EF> {
+    type MP = VerticalPair<RowMajorMatrixView<'a, EF>, RowMajorMatrixView<'a, EF>>;
 
     type Stage2PublicVar = Self::EF;
 

--- a/src/builder/folder.rs
+++ b/src/builder/folder.rs
@@ -1,52 +1,53 @@
 /// Constraint folders for the prover and verifier, adapted from Plonky3.
 use p3_air::{AirBuilder, ExtensionBuilder, RowWindow};
-use p3_field::{Algebra, BasedVectorSpace};
+use p3_field::{Algebra, BasedVectorSpace, ExtensionField, Field};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 
-use crate::types::{ExtVal, PackedExtVal, PackedVal, Val};
-
 use super::TwoStagedBuilder;
 
-#[derive(Debug)]
-pub struct ProverConstraintFolder<'a> {
-    pub preprocessed: RowWindow<'a, PackedVal>,
-    pub stage_1: RowMajorMatrixView<'a, PackedVal>,
-    pub stage_2: RowMajorMatrixView<'a, PackedExtVal>,
-    pub stage_1_public_values: &'a [Val],
-    pub stage_2_public_values: &'a [ExtVal],
-    pub is_first_row: PackedVal,
-    pub is_last_row: PackedVal,
-    pub is_transition: PackedVal,
-    pub alpha_powers: &'a [ExtVal],
-    pub decomposed_alpha_powers: &'a [Vec<Val>],
-    pub accumulator: PackedExtVal,
+/// Packed base-field values of `F`.
+type PackedVal<F> = <F as Field>::Packing;
+/// Packed extension-field values of `EF` over `F`.
+type PackedExt<F, EF> = <EF as ExtensionField<F>>::ExtensionPacking;
+
+pub struct ProverConstraintFolder<'a, F: Field, EF: ExtensionField<F>> {
+    pub preprocessed: RowWindow<'a, PackedVal<F>>,
+    pub stage_1: RowMajorMatrixView<'a, PackedVal<F>>,
+    pub stage_2: RowMajorMatrixView<'a, PackedExt<F, EF>>,
+    pub stage_1_public_values: &'a [F],
+    pub stage_2_public_values: &'a [EF],
+    pub is_first_row: PackedVal<F>,
+    pub is_last_row: PackedVal<F>,
+    pub is_transition: PackedVal<F>,
+    pub alpha_powers: &'a [EF],
+    pub decomposed_alpha_powers: &'a [Vec<F>],
+    pub accumulator: PackedExt<F, EF>,
     pub constraint_index: usize,
 }
 
 type ViewPair<'a, T> = VerticalPair<RowMajorMatrixView<'a, T>, RowMajorMatrixView<'a, T>>;
 
-#[derive(Debug)]
-pub struct VerifierConstraintFolder<'a> {
-    pub preprocessed: RowWindow<'a, ExtVal>,
-    pub stage_1: ViewPair<'a, ExtVal>,
-    pub stage_2: ViewPair<'a, ExtVal>,
-    pub stage_1_public_values: &'a [Val],
-    pub stage_2_public_values: &'a [ExtVal],
-    pub is_first_row: ExtVal,
-    pub is_last_row: ExtVal,
-    pub is_transition: ExtVal,
-    pub alpha: ExtVal,
-    pub accumulator: ExtVal,
+pub struct VerifierConstraintFolder<'a, F: Field, EF: ExtensionField<F>> {
+    pub preprocessed: RowWindow<'a, EF>,
+    pub stage_1: ViewPair<'a, EF>,
+    pub stage_2: ViewPair<'a, EF>,
+    pub stage_1_public_values: &'a [F],
+    pub stage_2_public_values: &'a [EF],
+    pub is_first_row: EF,
+    pub is_last_row: EF,
+    pub is_transition: EF,
+    pub alpha: EF,
+    pub accumulator: EF,
 }
 
-impl<'a> AirBuilder for ProverConstraintFolder<'a> {
-    type F = Val;
-    type Expr = PackedVal;
-    type Var = PackedVal;
-    type PreprocessedWindow = RowWindow<'a, PackedVal>;
-    type MainWindow = RowWindow<'a, PackedVal>;
-    type PublicVar = Val;
+impl<'a, F: Field, EF: ExtensionField<F>> AirBuilder for ProverConstraintFolder<'a, F, EF> {
+    type F = F;
+    type Expr = PackedVal<F>;
+    type Var = PackedVal<F>;
+    type PreprocessedWindow = RowWindow<'a, PackedVal<F>>;
+    type MainWindow = RowWindow<'a, PackedVal<F>>;
+    type PublicVar = F;
 
     #[inline]
     fn main(&self) -> Self::MainWindow {
@@ -80,19 +81,19 @@ impl<'a> AirBuilder for ProverConstraintFolder<'a> {
 
     #[inline]
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
-        let x: PackedVal = x.into();
+        let x: PackedVal<F> = x.into();
         let alpha_power = self.alpha_powers[self.constraint_index];
-        self.accumulator += Into::<PackedExtVal>::into(alpha_power) * x;
+        self.accumulator += Into::<PackedExt<F, EF>>::into(alpha_power) * x;
         self.constraint_index += 1;
     }
 
     #[inline]
     fn assert_zeros<const N: usize, I: Into<Self::Expr>>(&mut self, array: [I; N]) {
         let expr_array: [Self::Expr; N] = array.map(Into::into);
-        self.accumulator += PackedExtVal::from_basis_coefficients_fn(|i| {
+        self.accumulator += PackedExt::<F, EF>::from_basis_coefficients_fn(|i| {
             let alpha_powers = &self.decomposed_alpha_powers[i]
                 [self.constraint_index..(self.constraint_index + N)];
-            PackedVal::batched_linear_combination(&expr_array, alpha_powers)
+            PackedVal::<F>::batched_linear_combination(&expr_array, alpha_powers)
         });
         self.constraint_index += N;
     }
@@ -103,25 +104,25 @@ impl<'a> AirBuilder for ProverConstraintFolder<'a> {
     }
 }
 
-impl<'a> ExtensionBuilder for ProverConstraintFolder<'a> {
-    type EF = ExtVal;
-    type ExprEF = PackedExtVal;
-    type VarEF = PackedExtVal;
+impl<F: Field, EF: ExtensionField<F>> ExtensionBuilder for ProverConstraintFolder<'_, F, EF> {
+    type EF = EF;
+    type ExprEF = PackedExt<F, EF>;
+    type VarEF = PackedExt<F, EF>;
 
     /// Assert that an extension field expression is zero.
     fn assert_zero_ext<I>(&mut self, x: I)
     where
         I: Into<Self::ExprEF>,
     {
-        let x: PackedExtVal = x.into();
+        let x: PackedExt<F, EF> = x.into();
         let alpha_power = self.alpha_powers[self.constraint_index];
-        self.accumulator += Into::<PackedExtVal>::into(alpha_power) * x;
+        self.accumulator += Into::<PackedExt<F, EF>>::into(alpha_power) * x;
         self.constraint_index += 1;
     }
 }
 
-impl<'a> TwoStagedBuilder for ProverConstraintFolder<'a> {
-    type MP = RowMajorMatrixView<'a, PackedExtVal>;
+impl<'a, F: Field, EF: ExtensionField<F>> TwoStagedBuilder for ProverConstraintFolder<'a, F, EF> {
+    type MP = RowMajorMatrixView<'a, PackedExt<F, EF>>;
 
     type Stage2PublicVar = Self::EF;
 
@@ -134,13 +135,13 @@ impl<'a> TwoStagedBuilder for ProverConstraintFolder<'a> {
     }
 }
 
-impl<'a> AirBuilder for VerifierConstraintFolder<'a> {
-    type F = Val;
-    type Expr = ExtVal;
-    type Var = ExtVal;
-    type PreprocessedWindow = RowWindow<'a, ExtVal>;
-    type MainWindow = RowWindow<'a, ExtVal>;
-    type PublicVar = Val;
+impl<'a, F: Field, EF: ExtensionField<F>> AirBuilder for VerifierConstraintFolder<'a, F, EF> {
+    type F = F;
+    type Expr = EF;
+    type Var = EF;
+    type PreprocessedWindow = RowWindow<'a, EF>;
+    type MainWindow = RowWindow<'a, EF>;
+    type PublicVar = F;
 
     fn main(&self) -> Self::MainWindow {
         RowWindow::from_two_rows(self.stage_1.top.values, self.stage_1.bottom.values)
@@ -169,7 +170,7 @@ impl<'a> AirBuilder for VerifierConstraintFolder<'a> {
     }
 
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
-        let x: ExtVal = x.into();
+        let x: EF = x.into();
         self.accumulator *= self.alpha;
         self.accumulator += x;
     }
@@ -179,24 +180,24 @@ impl<'a> AirBuilder for VerifierConstraintFolder<'a> {
     }
 }
 
-impl<'a> ExtensionBuilder for VerifierConstraintFolder<'a> {
-    type EF = ExtVal;
-    type ExprEF = ExtVal;
-    type VarEF = ExtVal;
+impl<F: Field, EF: ExtensionField<F>> ExtensionBuilder for VerifierConstraintFolder<'_, F, EF> {
+    type EF = EF;
+    type ExprEF = EF;
+    type VarEF = EF;
 
     /// Assert that an extension field expression is zero.
     fn assert_zero_ext<I>(&mut self, x: I)
     where
         I: Into<Self::ExprEF>,
     {
-        let x: ExtVal = x.into();
+        let x: EF = x.into();
         self.accumulator *= self.alpha;
         self.accumulator += x;
     }
 }
 
-impl<'a> TwoStagedBuilder for VerifierConstraintFolder<'a> {
-    type MP = ViewPair<'a, ExtVal>;
+impl<'a, F: Field, EF: ExtensionField<F>> TwoStagedBuilder for VerifierConstraintFolder<'a, F, EF> {
+    type MP = ViewPair<'a, EF>;
 
     type Stage2PublicVar = Self::EF;
 

--- a/src/builder/symbolic.rs
+++ b/src/builder/symbolic.rs
@@ -2,7 +2,6 @@
 use p3_air::{Air, AirBuilder, ExtensionBuilder};
 use p3_field::{Algebra, Dup, Field, InjectiveMonomial, PrimeCharacteristicRing};
 use p3_matrix::dense::RowMajorMatrix;
-use p3_util::log2_ceil_usize;
 use std::fmt::Debug;
 use std::iter::{Product, Sum};
 use std::marker::PhantomData;
@@ -357,16 +356,6 @@ pub fn get_max_constraint_degree(constraints: &[SymbolicExpression<ExtVal>]) -> 
         .map(|c| c.degree_multiple())
         .max()
         .unwrap_or(0)
-}
-
-pub fn get_log_quotient_degree(max_constraint_degree: usize, is_zk: bool) -> usize {
-    // We pad to at least degree 2, since a quotient argument doesn't make sense with smaller degrees.
-    let constraint_degree = (max_constraint_degree + usize::from(is_zk)).max(2);
-
-    // The quotient's actual degree is approximately (max_constraint_degree - 1) n,
-    // where subtracting 1 comes from division by the vanishing polynomial.
-    // But we pad it to a power of two so that we can efficiently decompose the quotient.
-    log2_ceil_usize(constraint_degree - 1)
 }
 
 /// An `AirBuilder` for evaluating constraints symbolically, and recording them for later use.

--- a/src/builder/symbolic.rs
+++ b/src/builder/symbolic.rs
@@ -1,13 +1,11 @@
 /// Symbolic constraint builder and expressions, adapted from Plonky3.
 use p3_air::{Air, AirBuilder, ExtensionBuilder};
-use p3_field::{Algebra, Dup, Field, InjectiveMonomial, PrimeCharacteristicRing};
+use p3_field::{Algebra, Dup, ExtensionField, Field, InjectiveMonomial, PrimeCharacteristicRing};
 use p3_matrix::dense::RowMajorMatrix;
 use std::fmt::Debug;
 use std::iter::{Product, Sum};
 use std::marker::PhantomData;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-
-use crate::types::{ExtVal, Val};
 
 use super::TwoStagedBuilder;
 
@@ -188,9 +186,13 @@ impl<F: Field> Default for SymbolicExpression<F> {
     }
 }
 
-impl<F: Field> From<F> for SymbolicExpression<F> {
+/// Base-field values embed into expressions over any extension of the base
+/// field (including the base field itself, via the reflexive
+/// `ExtensionField<F> for F`). This single impl replaces both the same-field
+/// `From<F>` conversion and the old concrete `Val` → `ExtVal` lifting.
+impl<F: Field, EF: ExtensionField<F>> From<F> for SymbolicExpression<EF> {
     fn from(value: F) -> Self {
-        Self::Constant(value)
+        Self::Constant(value.into())
     }
 }
 
@@ -208,7 +210,7 @@ impl<F: Field> PrimeCharacteristicRing for SymbolicExpression<F> {
     }
 }
 
-impl<F: Field> Algebra<F> for SymbolicExpression<F> {}
+impl<F: Field, EF: ExtensionField<F>> Algebra<F> for SymbolicExpression<EF> {}
 
 impl<F: Field> Algebra<SymbolicVariable<F>> for SymbolicExpression<F> {}
 
@@ -328,16 +330,18 @@ impl<F: Field, T: Into<Self>> Product<T> for SymbolicExpression<F> {
     }
 }
 
-pub fn get_symbolic_constraints<A>(
+pub fn get_symbolic_constraints<F, EF, A>(
     air: &A,
     preprocessed_width: usize,
     stage_1_width: usize,
     stage_2_width: usize,
     num_public_values: usize,
     num_stage_2_public_values: usize,
-) -> Vec<SymbolicExpression<ExtVal>>
+) -> Vec<SymbolicExpression<EF>>
 where
-    A: Air<SymbolicAirBuilder>,
+    F: Field,
+    EF: ExtensionField<F>,
+    A: Air<SymbolicAirBuilder<F, EF>>,
 {
     let mut builder = SymbolicAirBuilder::new(
         preprocessed_width,
@@ -350,7 +354,7 @@ where
     builder.constraints
 }
 
-pub fn get_max_constraint_degree(constraints: &[SymbolicExpression<ExtVal>]) -> usize {
+pub fn get_max_constraint_degree<EF: Field>(constraints: &[SymbolicExpression<EF>]) -> usize {
     constraints
         .iter()
         .map(|c| c.degree_multiple())
@@ -359,17 +363,24 @@ pub fn get_max_constraint_degree(constraints: &[SymbolicExpression<ExtVal>]) -> 
 }
 
 /// An `AirBuilder` for evaluating constraints symbolically, and recording them for later use.
+///
+/// All variables and expressions are tagged with the extension field `EF`,
+/// even those referring to base-field trace columns. The tag only affects the
+/// type of embedded constants — using a single tag lets `Expr` and `ExprEF`
+/// be the same type, which sidesteps the coherence problems of converting
+/// between `SymbolicExpression<F>` and `SymbolicExpression<EF>`.
 #[derive(Debug)]
-pub struct SymbolicAirBuilder {
-    preprocessed: RowMajorMatrix<SymbolicVariable<Val>>,
-    stage_1: RowMajorMatrix<SymbolicVariable<Val>>,
-    stage_2: RowMajorMatrix<SymbolicVariable<ExtVal>>,
-    public_values: Vec<SymbolicVariable<Val>>,
-    stage_2_public_values: Vec<SymbolicVariable<ExtVal>>,
-    constraints: Vec<SymbolicExpression<ExtVal>>,
+pub struct SymbolicAirBuilder<F: Field, EF: ExtensionField<F>> {
+    preprocessed: RowMajorMatrix<SymbolicVariable<EF>>,
+    stage_1: RowMajorMatrix<SymbolicVariable<EF>>,
+    stage_2: RowMajorMatrix<SymbolicVariable<EF>>,
+    public_values: Vec<SymbolicVariable<EF>>,
+    stage_2_public_values: Vec<SymbolicVariable<EF>>,
+    constraints: Vec<SymbolicExpression<EF>>,
+    _phantom: PhantomData<F>,
 }
 
-impl SymbolicAirBuilder {
+impl<F: Field, EF: ExtensionField<F>> SymbolicAirBuilder<F, EF> {
     pub(crate) fn new(
         preprocessed_width: usize,
         stage_1_width: usize,
@@ -411,17 +422,18 @@ impl SymbolicAirBuilder {
             public_values,
             stage_2_public_values,
             constraints: vec![],
+            _phantom: PhantomData,
         }
     }
 }
 
-impl AirBuilder for SymbolicAirBuilder {
-    type F = Val;
-    type Expr = SymbolicExpression<Val>;
-    type Var = SymbolicVariable<Val>;
+impl<F: Field, EF: ExtensionField<F>> AirBuilder for SymbolicAirBuilder<F, EF> {
+    type F = F;
+    type Expr = SymbolicExpression<EF>;
+    type Var = SymbolicVariable<EF>;
     type PreprocessedWindow = RowMajorMatrix<Self::Var>;
     type MainWindow = RowMajorMatrix<Self::Var>;
-    type PublicVar = SymbolicVariable<Val>;
+    type PublicVar = SymbolicVariable<EF>;
 
     fn main(&self) -> Self::MainWindow {
         self.stage_1.clone()
@@ -450,7 +462,7 @@ impl AirBuilder for SymbolicAirBuilder {
     }
 
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
-        self.constraints.push(x.into().into());
+        self.constraints.push(x.into());
     }
 
     fn public_values(&self) -> &[Self::PublicVar] {
@@ -458,63 +470,10 @@ impl AirBuilder for SymbolicAirBuilder {
     }
 }
 
-impl Algebra<SymbolicExpression<Val>> for SymbolicExpression<ExtVal> {}
-
-impl From<SymbolicExpression<Val>> for SymbolicExpression<ExtVal> {
-    fn from(value: SymbolicExpression<Val>) -> Self {
-        match value {
-            SymbolicExpression::Variable(SymbolicVariable {
-                entry,
-                index,
-                _phantom,
-            }) => Self::Variable(SymbolicVariable {
-                entry,
-                index,
-                _phantom: PhantomData,
-            }),
-            SymbolicExpression::IsFirstRow => Self::IsFirstRow,
-            SymbolicExpression::IsLastRow => Self::IsLastRow,
-            SymbolicExpression::IsTransition => Self::IsTransition,
-            SymbolicExpression::Constant(f) => Self::Constant(f.into()),
-            SymbolicExpression::Add {
-                x,
-                y,
-                degree_multiple,
-            } => Self::Add {
-                x: Self::from(*x).into(),
-                y: Self::from(*y).into(),
-                degree_multiple,
-            },
-            SymbolicExpression::Sub {
-                x,
-                y,
-                degree_multiple,
-            } => Self::Sub {
-                x: Self::from(*x).into(),
-                y: Self::from(*y).into(),
-                degree_multiple,
-            },
-            SymbolicExpression::Mul {
-                x,
-                y,
-                degree_multiple,
-            } => Self::Mul {
-                x: Self::from(*x).into(),
-                y: Self::from(*y).into(),
-                degree_multiple,
-            },
-            SymbolicExpression::Neg { x, degree_multiple } => Self::Neg {
-                x: Self::from(*x).into(),
-                degree_multiple,
-            },
-        }
-    }
-}
-
-impl ExtensionBuilder for SymbolicAirBuilder {
-    type EF = ExtVal;
-    type ExprEF = SymbolicExpression<ExtVal>;
-    type VarEF = SymbolicVariable<ExtVal>;
+impl<F: Field, EF: ExtensionField<F>> ExtensionBuilder for SymbolicAirBuilder<F, EF> {
+    type EF = EF;
+    type ExprEF = SymbolicExpression<EF>;
+    type VarEF = SymbolicVariable<EF>;
 
     fn assert_zero_ext<I>(&mut self, x: I)
     where
@@ -524,7 +483,7 @@ impl ExtensionBuilder for SymbolicAirBuilder {
     }
 }
 
-impl TwoStagedBuilder for SymbolicAirBuilder {
+impl<F: Field, EF: ExtensionField<F>> TwoStagedBuilder for SymbolicAirBuilder<F, EF> {
     type MP = RowMajorMatrix<Self::VarEF>;
 
     type Stage2PublicVar = Self::VarEF;

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,4 +93,20 @@ pub trait StarkGenericConfig {
     /// the quotient degree, exceeds this bound. For a FRI-based PCS this is
     /// the field's two-adicity minus the log blowup.
     fn max_log_degree(&self) -> usize;
+
+    /// The largest quotient degree — as a multiple of the trace degree —
+    /// that the PCS can serve trace evaluations for.
+    ///
+    /// The prover evaluates the constraints on a domain `quotient_degree`
+    /// times larger than the trace domain, obtained from the PCS via
+    /// `get_evaluations_on_domain`. For a FRI-based PCS this only works up
+    /// to the blowup factor: the committed low-degree extension has
+    /// `2^log_blowup · N` evaluations, and asking for a larger domain
+    /// produces invalid proofs. Since the quotient degree is
+    /// `next_power_of_two(max_constraint_degree - 1)`, this bounds the
+    /// constraint degree: `2^log_blowup + 1` (degree 3 at `log_blowup = 1`).
+    ///
+    /// [`System::new`](crate::system::System::new) rejects circuits whose
+    /// constraint degree requires a larger quotient degree.
+    fn max_quotient_degree(&self) -> usize;
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,96 @@
+//! Generic STARK configuration.
+//!
+//! [`StarkGenericConfig`] bundles the three choices that instantiate the
+//! protocol: the polynomial commitment scheme, the challenge (extension)
+//! field, and the Fiat-Shamir challenger. The base field is determined
+//! transitively by the PCS ([`Val`]). The prover, verifier and system are
+//! generic over an implementation of this trait; see
+//! [`crate::types::GoldilocksKeccakConfig`] for the reference instantiation.
+
+use p3_challenger::{CanObserve, CanSample, FieldChallenger};
+use p3_commit::{Pcs, PolynomialSpace};
+use p3_field::{ExtensionField, Field};
+
+/// The base field of a configuration, as determined by its PCS domain.
+pub type Val<SC> = <<<SC as StarkGenericConfig>::Pcs as Pcs<
+    <SC as StarkGenericConfig>::Challenge,
+    <SC as StarkGenericConfig>::Challenger,
+>>::Domain as PolynomialSpace>::Val;
+
+/// The evaluation domain type of a configuration's PCS.
+pub type Domain<SC> = <<SC as StarkGenericConfig>::Pcs as Pcs<
+    <SC as StarkGenericConfig>::Challenge,
+    <SC as StarkGenericConfig>::Challenger,
+>>::Domain;
+
+/// The commitment type of a configuration's PCS.
+pub type Com<SC> = <<SC as StarkGenericConfig>::Pcs as Pcs<
+    <SC as StarkGenericConfig>::Challenge,
+    <SC as StarkGenericConfig>::Challenger,
+>>::Commitment;
+
+/// The opening proof type of a configuration's PCS.
+pub type PcsProof<SC> = <<SC as StarkGenericConfig>::Pcs as Pcs<
+    <SC as StarkGenericConfig>::Challenge,
+    <SC as StarkGenericConfig>::Challenger,
+>>::Proof;
+
+/// The error type of a configuration's PCS.
+pub type PcsError<SC> = <<SC as StarkGenericConfig>::Pcs as Pcs<
+    <SC as StarkGenericConfig>::Challenge,
+    <SC as StarkGenericConfig>::Challenger,
+>>::Error;
+
+/// The prover data type of a configuration's PCS.
+pub type PcsData<SC> = <<SC as StarkGenericConfig>::Pcs as Pcs<
+    <SC as StarkGenericConfig>::Challenge,
+    <SC as StarkGenericConfig>::Challenger,
+>>::ProverData;
+
+/// Evaluations of committed polynomials over a domain.
+pub type EvaluationsOnDomain<'a, SC> = <<SC as StarkGenericConfig>::Pcs as Pcs<
+    <SC as StarkGenericConfig>::Challenge,
+    <SC as StarkGenericConfig>::Challenger,
+>>::EvaluationsOnDomain<'a>;
+
+/// Packed base-field values of a configuration.
+pub type PackedVal<SC> = <Val<SC> as Field>::Packing;
+
+/// Packed challenge-field values of a configuration.
+pub type PackedChallenge<SC> =
+    <<SC as StarkGenericConfig>::Challenge as ExtensionField<Val<SC>>>::ExtensionPacking;
+
+/// Configuration of a STARK system.
+pub trait StarkGenericConfig {
+    /// The PCS used to commit to trace polynomials.
+    type Pcs: Pcs<Self::Challenge, Self::Challenger>;
+
+    /// The field from which random challenges are drawn. Its size bounds the
+    /// Schwartz-Zippel terms of the soundness error, so it must be large
+    /// enough for the target security level (see the soundness argument in
+    /// the verifier module docs).
+    type Challenge: ExtensionField<Val<Self>>;
+
+    /// The Fiat-Shamir challenger.
+    type Challenger: FieldChallenger<Val<Self>> + CanObserve<Com<Self>> + CanSample<Self::Challenge>;
+
+    /// Returns a reference to the PCS.
+    fn pcs(&self) -> &Self::Pcs;
+
+    /// Returns a fresh challenger.
+    ///
+    /// # Transcript contract
+    /// Implementations must seed the challenger with a domain-separation tag
+    /// and a digest of all protocol parameters (PCS configuration, security
+    /// parameters), so that transcripts produced under different parameters
+    /// never collide. The circuit shape is bound separately via
+    /// `System::observe_shape`.
+    fn initialise_challenger(&self) -> Self::Challenger;
+
+    /// The largest log2 polynomial degree the PCS can commit to and open.
+    ///
+    /// The verifier rejects proofs whose claimed trace degree, multiplied by
+    /// the quotient degree, exceeds this bound. For a FRI-based PCS this is
+    /// the field's two-adicity minus the log blowup.
+    fn max_log_degree(&self) -> usize;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,11 @@ pub use p3_matrix;
 macro_rules! ensure {
     ($condition:expr, $err:expr) => {
         if !$condition {
-            eprintln!("assertion failed on file {} line {}", file!(), line!());
+            tracing::debug!(
+                "verification check failed on file {} line {}",
+                file!(),
+                line!()
+            );
             return std::result::Result::Err($err.into());
         }
     };
@@ -27,15 +31,4 @@ macro_rules! ensure_eq {
     ($a:expr, $b:expr, $err:expr) => {
         $crate::ensure!(($a) == ($b), $err);
     };
-}
-
-#[macro_export]
-macro_rules! benchmark {
-    ($bench:expr, $msg:expr $(,$msg_args:expr)*) => {{
-        let now = std::time::Instant::now();
-        let result = std::hint::black_box($bench);
-        print!($msg $(,$msg_args)*);
-        println!("{:?}", now.elapsed());
-        result
-    }};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod builder;
+pub mod config;
 pub mod lookup;
 pub mod prover;
 pub mod system;

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -1,12 +1,9 @@
 use p3_air::{Air, BaseAir, ExtensionBuilder, WindowAccess};
-use p3_field::{PrimeCharacteristicRing, batch_multiplicative_inverse};
+use p3_field::{ExtensionField, Field, PrimeCharacteristicRing, batch_multiplicative_inverse};
 use p3_matrix::{Matrix, dense::RowMajorMatrix};
 use p3_maybe_rayon::prelude::*;
 
-use crate::{
-    builder::{TwoStagedBuilder, symbolic::SymbolicExpression},
-    types::{ExtVal, Val},
-};
+use crate::builder::{TwoStagedBuilder, symbolic::SymbolicExpression};
 
 /// Each circuit is required to have 4 arguments for the second stage. Namely,
 /// the lookup challenge, fingerprint challenge, current accumulator and next
@@ -51,14 +48,14 @@ impl<Expr> Lookup<Expr> {
     }
 }
 
-pub struct LookupAir<A> {
+pub struct LookupAir<A, F: Field> {
     pub inner_air: A,
-    pub lookups: Vec<Lookup<SymbolicExpression<Val>>>,
-    pub preprocessed: Option<RowMajorMatrix<Val>>,
+    pub lookups: Vec<Lookup<SymbolicExpression<F>>>,
+    pub preprocessed: Option<RowMajorMatrix<F>>,
 }
 
-impl<A: BaseAir<Val>> LookupAir<A> {
-    pub fn new(inner_air: A, lookups: Vec<Lookup<SymbolicExpression<Val>>>) -> Self {
+impl<A: BaseAir<F>, F: Field> LookupAir<A, F> {
+    pub fn new(inner_air: A, lookups: Vec<Lookup<SymbolicExpression<F>>>) -> Self {
         let preprocessed = inner_air.preprocessed_trace();
         Self {
             inner_air,
@@ -87,10 +84,10 @@ where
         .fold(F::ZERO, |acc, coeff| acc * r.clone() + coeff.into())
 }
 
-impl Lookup<SymbolicExpression<Val>> {
+impl<F: Field> Lookup<SymbolicExpression<F>> {
     /// Computes the concrete lookup attributes for its respective expressions
     /// given a trace row and a preprocessed trace row.
-    pub fn compute_expr(&self, row: &[Val], preprocessed: Option<&[Val]>) -> Lookup<Val> {
+    pub fn compute_expr(&self, row: &[F], preprocessed: Option<&[F]>) -> Lookup<F> {
         let multiplicity = self.multiplicity.interpret(row, preprocessed);
         let args = self
             .args
@@ -101,19 +98,19 @@ impl Lookup<SymbolicExpression<Val>> {
     }
 }
 
-impl Lookup<Val> {
+impl<F: Field> Lookup<F> {
     /// Computes the stage 2 traces and the intermediate accumulators for each
     /// circuit given a lookup challenge, a fingerprint challenge and the current
     /// accumulator value (computed from the initial claims).
     ///
     /// Note: the lookups are expected to be fully padded. That is, for each
     /// circuit, every row must have the exact same number of lookups.
-    pub fn stage_2_traces(
+    pub fn stage_2_traces<EF: ExtensionField<F>>(
         lookups: &[Vec<Vec<Self>>],
-        lookup_challenge: ExtVal,
-        fingerprint_challenge: &ExtVal,
-        mut accumulator: ExtVal,
-    ) -> (Vec<RowMajorMatrix<ExtVal>>, Vec<ExtVal>) {
+        lookup_challenge: EF,
+        fingerprint_challenge: &EF,
+        mut accumulator: EF,
+    ) -> (Vec<RowMajorMatrix<EF>>, Vec<EF>) {
         // Number of lookups per circuit. Every row in a circuit is assumed to
         // have the same number of lookups (the lookups are expected to be fully
         // padded), so this is taken from the first row.
@@ -128,7 +125,7 @@ impl Lookup<Val> {
         // output Vec without tree-reducing worker buffers.
         let _g = tracing::info_span!("stark/lookup_messages").entered();
         let flat: Vec<&Self> = lookups.iter().flatten().flatten().collect();
-        let messages: Vec<ExtVal> = flat
+        let messages: Vec<EF> = flat
             .par_iter()
             .map(|lookup| lookup.compute_message(lookup_challenge, fingerprint_challenge))
             .collect();
@@ -164,7 +161,7 @@ impl Lookup<Val> {
                         row.push(accumulator);
                         row.extend(row_lookups.iter().zip(row_messages_inverses).map(
                             |(lookup, &message_inverse)| {
-                                accumulator += ExtVal::from(lookup.multiplicity) * message_inverse;
+                                accumulator += EF::from(lookup.multiplicity) * message_inverse;
                                 message_inverse
                             },
                         ));
@@ -182,29 +179,35 @@ impl Lookup<Val> {
         (traces, intermediate_accumulators)
     }
 
-    fn compute_message(&self, lookup_challenge: ExtVal, fingerprint_challenge: &ExtVal) -> ExtVal {
+    fn compute_message<EF: ExtensionField<F>>(
+        &self,
+        lookup_challenge: EF,
+        fingerprint_challenge: &EF,
+    ) -> EF {
         let fingerprint = fingerprint(fingerprint_challenge, self.args.iter().cloned());
         lookup_challenge + fingerprint
     }
 }
 
-impl<A> BaseAir<Val> for LookupAir<A>
+impl<A, F> BaseAir<F> for LookupAir<A, F>
 where
-    A: BaseAir<Val>,
+    A: BaseAir<F>,
+    F: Field,
 {
     fn width(&self) -> usize {
         self.inner_air.width()
     }
 
-    fn preprocessed_trace(&self) -> Option<RowMajorMatrix<Val>> {
+    fn preprocessed_trace(&self) -> Option<RowMajorMatrix<F>> {
         self.preprocessed.clone()
     }
 }
 
-impl<A, AB> Air<AB> for LookupAir<A>
+impl<A, F, AB> Air<AB> for LookupAir<A, F>
 where
     A: Air<AB>,
-    AB: TwoStagedBuilder<F = Val, EF = ExtVal>,
+    F: Field,
+    AB: TwoStagedBuilder<F = F>,
 {
     fn eval(&self, builder: &mut AB) {
         if self.preprocessed.is_some() {
@@ -217,11 +220,11 @@ where
     }
 }
 
-impl<A> LookupAir<A> {
+impl<A, F: Field> LookupAir<A, F> {
     fn eval_with_preprocessed_row<AB>(&self, builder: &mut AB, preprocessed_row: Option<&[AB::Var]>)
     where
         A: Air<AB>,
-        AB: TwoStagedBuilder<F = Val, EF = ExtVal>,
+        AB: TwoStagedBuilder<F = F>,
     {
         // Call `eval` for regular stage 1 constraints.
         self.inner_air.eval(builder);
@@ -287,7 +290,7 @@ mod tests {
     use crate::{
         builder::symbolic::var,
         system::{ProverKey, System, SystemWitness},
-        types::{CommitmentParameters, FriParameters},
+        types::{CommitmentParameters, FriParameters, Val},
     };
 
     use super::*;

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -384,14 +384,17 @@ mod tests {
         query_proof_of_work_bits: 0,
     };
 
-    fn system() -> (System<CS>, ProverKey) {
+    fn system() -> (
+        System<GoldilocksKeccakConfig, CS>,
+        ProverKey<GoldilocksKeccakConfig>,
+    ) {
         let config = GoldilocksKeccakConfig::new(COMMITMENT_PARAMETERS, FRI_PARAMETERS);
         let even = LookupAir::new(CS::Even, CS::Even.lookups());
         let odd = LookupAir::new(CS::Odd, CS::Odd.lookups());
         System::new(config, [even, odd])
     }
 
-    fn witness(system: &System<CS>) -> SystemWitness {
+    fn witness(system: &System<GoldilocksKeccakConfig, CS>) -> SystemWitness<Val> {
         let f = Val::from_u32;
         #[rustfmt::skip]
         let witness = SystemWitness::from_stage_1(

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -290,7 +290,7 @@ mod tests {
     use crate::{
         builder::symbolic::var,
         system::{ProverKey, System, SystemWitness},
-        types::{CommitmentParameters, FriParameters, Val},
+        types::{CommitmentParameters, FriParameters, GoldilocksKeccakConfig, Val},
     };
 
     use super::*;
@@ -371,10 +371,24 @@ mod tests {
                 .assert_one(input * input_inverse);
         }
     }
-    fn system(commitment_parameters: CommitmentParameters) -> (System<CS>, ProverKey) {
+    const COMMITMENT_PARAMETERS: CommitmentParameters = CommitmentParameters {
+        log_blowup: 1,
+        cap_height: 0,
+    };
+
+    const FRI_PARAMETERS: FriParameters = FriParameters {
+        log_final_poly_len: 0,
+        max_log_arity: 1,
+        num_queries: 64,
+        commit_proof_of_work_bits: 0,
+        query_proof_of_work_bits: 0,
+    };
+
+    fn system() -> (System<CS>, ProverKey) {
+        let config = GoldilocksKeccakConfig::new(COMMITMENT_PARAMETERS, FRI_PARAMETERS);
         let even = LookupAir::new(CS::Even, CS::Even.lookups());
         let odd = LookupAir::new(CS::Odd, CS::Odd.lookups());
-        System::new(commitment_parameters, [even, odd])
+        System::new(config, [even, odd])
     }
 
     fn witness(system: &System<CS>) -> SystemWitness {
@@ -414,44 +428,28 @@ mod tests {
         witness
     }
 
-    const FRI_PARAMETERS: FriParameters = FriParameters {
-        log_final_poly_len: 0,
-        max_log_arity: 1,
-        num_queries: 64,
-        commit_proof_of_work_bits: 0,
-        query_proof_of_work_bits: 0,
-    };
-
     #[test]
     fn lookup_test() {
-        let commitment_parameters = CommitmentParameters {
-            log_blowup: 1,
-            cap_height: 0,
-        };
-        let (system, key) = system(commitment_parameters);
+        let (system, key) = system();
         let witness = witness(&system);
         let f = Val::from_u32;
         let claim = &[f(0), f(4), f(1)];
-        let proof = system.prove(FRI_PARAMETERS, &key, claim, witness);
-        system.verify(FRI_PARAMETERS, claim, &proof).unwrap();
+        let proof = system.prove(&key, claim, witness);
+        system.verify(claim, &proof).unwrap();
     }
 
     #[test]
     fn test_claim_split_rejected() {
-        let commitment_parameters = CommitmentParameters {
-            log_blowup: 1,
-            cap_height: 0,
-        };
-        let (system, key) = system(commitment_parameters);
+        let (system, key) = system();
         let witness = witness(&system);
         let f = Val::from_u32;
         // Prove a single claim, then attempt to verify with the same values
         // regrouped into two claims. The transcript is length-prefixed, so the
         // regrouped claims must yield different challenges and fail.
         let claim = &[f(0), f(4), f(1)];
-        let proof = system.prove(FRI_PARAMETERS, &key, claim, witness);
+        let proof = system.prove(&key, claim, witness);
         let split_claims: &[&[Val]] = &[&[f(0), f(4)], &[f(1)]];
-        let result = system.verify_multiple_claims(FRI_PARAMETERS, split_claims, &proof);
+        let result = system.verify_multiple_claims(split_claims, &proof);
         assert!(result.is_err());
     }
 }

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -374,13 +374,7 @@ mod tests {
         System::new(commitment_parameters, [even, odd])
     }
 
-    #[test]
-    fn lookup_test() {
-        let commitment_parameters = CommitmentParameters {
-            log_blowup: 1,
-            cap_height: 0,
-        };
-        let (system, key) = system(commitment_parameters);
+    fn witness(system: &System<CS>) -> SystemWitness {
         let f = Val::from_u32;
         #[rustfmt::skip]
         let witness = SystemWitness::from_stage_1(
@@ -412,17 +406,49 @@ mod tests {
                     6,
                 ),
             ],
-            &system,
+            system,
         );
-        let claim = &[f(0), f(4), f(1)];
-        let fri_parameters = FriParameters {
-            log_final_poly_len: 0,
-            max_log_arity: 1,
-            num_queries: 64,
-            commit_proof_of_work_bits: 0,
-            query_proof_of_work_bits: 0,
+        witness
+    }
+
+    const FRI_PARAMETERS: FriParameters = FriParameters {
+        log_final_poly_len: 0,
+        max_log_arity: 1,
+        num_queries: 64,
+        commit_proof_of_work_bits: 0,
+        query_proof_of_work_bits: 0,
+    };
+
+    #[test]
+    fn lookup_test() {
+        let commitment_parameters = CommitmentParameters {
+            log_blowup: 1,
+            cap_height: 0,
         };
-        let proof = system.prove(fri_parameters, &key, claim, witness);
-        system.verify(fri_parameters, claim, &proof).unwrap();
+        let (system, key) = system(commitment_parameters);
+        let witness = witness(&system);
+        let f = Val::from_u32;
+        let claim = &[f(0), f(4), f(1)];
+        let proof = system.prove(FRI_PARAMETERS, &key, claim, witness);
+        system.verify(FRI_PARAMETERS, claim, &proof).unwrap();
+    }
+
+    #[test]
+    fn test_claim_split_rejected() {
+        let commitment_parameters = CommitmentParameters {
+            log_blowup: 1,
+            cap_height: 0,
+        };
+        let (system, key) = system(commitment_parameters);
+        let witness = witness(&system);
+        let f = Val::from_u32;
+        // Prove a single claim, then attempt to verify with the same values
+        // regrouped into two claims. The transcript is length-prefixed, so the
+        // regrouped claims must yield different challenges and fail.
+        let claim = &[f(0), f(4), f(1)];
+        let proof = system.prove(FRI_PARAMETERS, &key, claim, witness);
+        let split_claims: &[&[Val]] = &[&[f(0), f(4)], &[f(1)]];
+        let result = system.verify_multiple_claims(FRI_PARAMETERS, split_claims, &proof);
+        assert!(result.is_err());
     }
 }

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -358,9 +358,7 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a>>> System<A> {
             .enumerate()
             .flat_map(|(idx, ((circuit, log_degree), next_acc))| {
                 let air = &circuit.air;
-                // quotient degree is at most 1 less than the max degree, padded to a power of two
-                let quotient_degree =
-                    (circuit.max_constraint_degree.max(2) - 1).next_power_of_two();
+                let quotient_degree = circuit.quotient_degree();
                 let log_quotient_degree = log2_strict_usize(quotient_degree);
                 let trace_domain = <Pcs as PcsTrait<ExtVal, Challenger>>::natural_domain_for_degree(
                     pcs,

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1,13 +1,17 @@
 //! Multi-circuit STARK prover.
 //!
-//! The proving protocol proceeds in several stages:
+//! The proving protocol proceeds in several stages sharing one Fiat-Shamir
+//! transcript. The challenger starts from a seed binding a domain tag and all
+//! protocol parameters (see the transcript contract on
+//! [`StarkGenericConfig::initialise_challenger`]), and the system shape
+//! (circuit count, widths, constraint counts, degrees)
+//! is observed before any commitment.
 //!
 //! 1. **Stage 1 — Main traces**: Each circuit's execution trace is committed via the
-//!    configuration's PCS (FRI over Goldilocks with Keccak-256 hashing in the
-//!    reference config). The preprocessed commitment (if any), stage-1 commitment,
-//!    trace heights, and claims are observed into the Fiat-Shamir challenger. Claims
-//!    must be observed before lookup challenges are sampled; otherwise the prover could
-//!    choose claims adaptively to balance the lookup accumulator.
+//!    configuration's PCS. The preprocessed commitment (if any), stage-1 commitment,
+//!    trace heights, and length-prefixed claims are observed into the challenger.
+//!    Claims must be observed before lookup challenges are sampled; otherwise the
+//!    prover could choose claims adaptively to balance the lookup accumulator.
 //!
 //! 2. **Lookup challenges**: The challenger samples two independent challenges:
 //!    `lookup_argument_challenge` (β) and `fingerprint_challenge` (γ). An initial
@@ -17,7 +21,8 @@
 //! 3. **Stage 2 — Lookup traces**: For each circuit, the lookup traces are computed
 //!    (running accumulator and message inverses per row) and committed via PCS. Each
 //!    circuit produces an intermediate accumulator value recording where its running
-//!    sum ended up; the verifier will check that the last one is zero.
+//!    sum ended up; these are observed into the challenger, and the verifier will
+//!    check that the last one is zero.
 //!
 //! 4. **Quotient polynomial**: A constraint challenge (α) is sampled and used to fold
 //!    all constraints via powers of α. The folded constraint polynomial is divided by
@@ -47,8 +52,8 @@
 //! - k_i — number of constraints in circuit i (after lookup expansion)
 //! - d_i — maximum constraint degree multiple of circuit i
 //! - q_i = next_pow2(max(d_i, 2) − 1) — quotient polynomial degree
-//! - D — extension field dimension (2 in the reference config:
-//!   `BinomialExtensionField<Goldilocks, 2>`)
+//! - D — dimension of the challenge (extension) field over the base field
+//!   (2 in the reference config)
 //! - B = 2^log_blowup — FRI blowup factor
 //! - Q = num_queries — FRI query repetitions
 //! - a = max_log_arity — FRI folding arity (log₂)

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -154,11 +154,12 @@ use std::ops::Deref;
 
 use crate::{
     builder::folder::ProverConstraintFolder,
+    config::StarkGenericConfig,
     lookup::{Lookup, fingerprint},
     system::{ProverKey, System, SystemWitness},
     types::{
-        Challenger, Commitment, Domain, EvaluationsOnDomain, ExtVal, FriParameters, PackedExtVal,
-        PackedVal, Pcs, PcsProof, StarkConfig, Val,
+        Challenger, Commitment, Domain, EvaluationsOnDomain, ExtVal, PackedExtVal, PackedVal, Pcs,
+        PcsProof, Val,
     },
 };
 use bincode::{
@@ -226,14 +227,8 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> Sys
     /// Generates a STARK proof for the system with a single claim.
     ///
     /// This is a convenience wrapper around [`Self::prove_multiple_claims`].
-    pub fn prove(
-        &self,
-        fri_parameters: FriParameters,
-        key: &ProverKey,
-        claim: &[Val],
-        witness: SystemWitness,
-    ) -> Proof {
-        self.prove_multiple_claims(fri_parameters, key, &[claim], witness)
+    pub fn prove(&self, key: &ProverKey, claim: &[Val], witness: SystemWitness) -> Proof {
+        self.prove_multiple_claims(key, &[claim], witness)
     }
 
     /// Generates a STARK proof for the system with multiple claims.
@@ -243,18 +238,17 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> Sys
     #[tracing::instrument(level = "info", skip_all, name = "stark/prove")]
     pub fn prove_multiple_claims(
         &self,
-        fri_parameters: FriParameters,
         key: &ProverKey,
         claims: &[&[Val]],
         witness: SystemWitness,
     ) -> Proof {
         // initialize pcs and challenger
-        let config = StarkConfig::new(self.commitment_parameters, fri_parameters);
-        let pcs = config.pcs();
-        let mut challenger = config.initialise_challenger();
+        let pcs = self.config.pcs();
+        let mut challenger = self.config.initialise_challenger();
 
-        // bind the protocol parameters and system shape into the transcript
-        self.observe_shape(&fri_parameters, &mut challenger);
+        // Bind the system shape into the transcript. The protocol parameters
+        // are already bound via the challenger seed.
+        self.observe_shape(&mut challenger);
 
         // Cost: "Stage 1 commit" — coset LDE (FFT) of each trace from n_i to
         // n_i·B rows, then Merkle tree. FFT work: Σ w_i · n_i · B · log₂(n_i·B).
@@ -453,7 +447,9 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> Sys
                 pcs,
                 1 << log_degree,
             );
-            let zeta_next = zeta * trace_domain.subgroup_generator();
+            let zeta_next = trace_domain
+                .next_point(zeta)
+                .expect("domain has no next point");
             round1_openings.push(vec![zeta, zeta_next]);
             round2_openings.push(vec![zeta, zeta_next]);
             round3_openings.extend(vec![vec![zeta]; quotient_degree]);

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -253,6 +253,9 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a>>> System<A> {
         let pcs = config.pcs();
         let mut challenger = config.initialise_challenger();
 
+        // bind the protocol parameters and system shape into the transcript
+        self.observe_shape(&fri_parameters, &mut challenger);
+
         // Cost: "Stage 1 commit" — coset LDE (FFT) of each trace from n_i to
         // n_i·B rows, then Merkle tree. FFT work: Σ w_i · n_i · B · log₂(n_i·B).
         let _g = tracing::info_span!("stark/stage1_commit").entered();
@@ -274,15 +277,20 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a>>> System<A> {
         }
         challenger.observe(stage_1_trace_commit.clone());
 
-        // observe the traces' heights. TODO: is this necessary?
+        // Observe the traces' heights. This binds the proof to specific domain
+        // sizes; the verifier reads these from the (untrusted) proof, so they
+        // must influence every subsequent challenge.
         for log_degree in &log_degrees {
             challenger.observe(Val::from_usize(*log_degree));
         }
 
-        // observe the claims
-        // this has to be done before generating the lookup argument challenge
-        // otherwise the lookup argument can be attacked
+        // Observe the claims, length-prefixed so that distinct claim
+        // structures (e.g. [[a, b]] vs [[a], [b]]) yield distinct transcripts.
+        // This has to be done before generating the lookup argument challenge,
+        // otherwise the lookup argument can be attacked.
+        challenger.observe(Val::from_usize(claims.len()));
         for claim in claims {
+            challenger.observe(Val::from_usize(claim.len()));
             challenger.observe_slice(claim);
         }
 
@@ -324,6 +332,13 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a>>> System<A> {
             <Pcs as PcsTrait<ExtVal, Challenger>>::commit(pcs, evaluations);
         drop(_g);
         challenger.observe(stage_2_trace_commit.clone());
+
+        // Observe the intermediate accumulators. They enter the constraints as
+        // public values, so later challenges (α, ζ) must depend on them
+        // directly rather than only through the quotient commitment.
+        for acc in &intermediate_accumulators {
+            challenger.observe_algebra_element(*acc);
+        }
 
         // generate constraint challenge
         let constraint_challenge: ExtVal = challenger.sample_algebra_element();

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -3,8 +3,8 @@
 //! The proving protocol proceeds in several stages:
 //!
 //! 1. **Stage 1 — Main traces**: Each circuit's execution trace is committed via the
-//!    PCS (FRI-based polynomial commitment over Goldilocks with degree-2 extension and
-//!    Keccak-256 hashing). The preprocessed commitment (if any), stage-1 commitment,
+//!    configuration's PCS (FRI over Goldilocks with Keccak-256 hashing in the
+//!    reference config). The preprocessed commitment (if any), stage-1 commitment,
 //!    trace heights, and claims are observed into the Fiat-Shamir challenger. Claims
 //!    must be observed before lookup challenges are sampled; otherwise the prover could
 //!    choose claims adaptively to balance the lookup accumulator.
@@ -47,7 +47,8 @@
 //! - k_i — number of constraints in circuit i (after lookup expansion)
 //! - d_i — maximum constraint degree multiple of circuit i
 //! - q_i = next_pow2(max(d_i, 2) − 1) — quotient polynomial degree
-//! - D = 2 — extension field dimension (`BinomialExtensionField<Goldilocks, 2>`)
+//! - D — extension field dimension (2 in the reference config:
+//!   `BinomialExtensionField<Goldilocks, 2>`)
 //! - B = 2^log_blowup — FRI blowup factor
 //! - Q = num_queries — FRI query repetitions
 //! - a = max_log_arity — FRI folding arity (log₂)

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -222,7 +222,7 @@ impl Proof {
     }
 }
 
-impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a>>> System<A> {
+impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> System<A> {
     /// Generates a STARK proof for the system with a single claim.
     ///
     /// This is a convenience wrapper around [`Self::prove_multiple_claims`].
@@ -508,7 +508,7 @@ fn quotient_values<A>(
     constraint_count: usize,
 ) -> Vec<ExtVal>
 where
-    A: for<'a> Air<ProverConstraintFolder<'a>>,
+    A: for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>,
 {
     let quotient_size = quotient_domain.size();
     let stage_1_width = stage_1_on_quotient_domain.width();
@@ -611,7 +611,7 @@ fn quotient_values_inner<A>(
     i_start: usize,
 ) -> impl Iterator<Item = BinomialExtensionField<Val, 2>>
 where
-    A: for<'a> Air<ProverConstraintFolder<'a>>,
+    A: for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>,
 {
     let i_range = i_start..i_start + PackedVal::WIDTH;
 

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -154,13 +154,12 @@ use std::ops::Deref;
 
 use crate::{
     builder::folder::ProverConstraintFolder,
-    config::StarkGenericConfig,
+    config::{
+        Com, Domain, EvaluationsOnDomain, PackedChallenge, PackedVal, PcsProof, StarkGenericConfig,
+        Val,
+    },
     lookup::{Lookup, fingerprint},
     system::{ProverKey, System, SystemWitness},
-    types::{
-        Challenger, Commitment, Domain, EvaluationsOnDomain, ExtVal, PackedExtVal, PackedVal, Pcs,
-        PcsProof, Val,
-    },
 };
 use bincode::{
     config::{Configuration, Fixint, LittleEndian, standard},
@@ -169,11 +168,8 @@ use bincode::{
 };
 use p3_air::{Air, BaseAir, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
-use p3_commit::{LagrangeSelectors, OpenedValuesForRound, Pcs as PcsTrait, PolynomialSpace};
-use p3_field::{
-    BasedVectorSpace, Field, PackedValue, PrimeCharacteristicRing,
-    extension::BinomialExtensionField,
-};
+use p3_commit::{LagrangeSelectors, OpenedValuesForRound, Pcs, PolynomialSpace};
+use p3_field::{BasedVectorSpace, Field, PackedValue, PrimeCharacteristicRing};
 use p3_matrix::{Matrix, dense::RowMajorMatrix};
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
@@ -181,32 +177,33 @@ use serde::{Deserialize, Serialize};
 
 /// Polynomial commitments included in the proof.
 #[derive(Serialize, Deserialize)]
-pub struct Commitments {
+pub struct Commitments<Com> {
     /// Commitment to the stage 1 (main) execution traces.
-    pub stage_1_trace: Commitment,
+    pub stage_1_trace: Com,
     /// Commitment to the stage 2 (lookup) execution traces.
-    pub stage_2_trace: Commitment,
+    pub stage_2_trace: Com,
     /// Commitment to the quotient polynomial chunks.
-    pub quotient_chunks: Commitment,
+    pub quotient_chunks: Com,
 }
 
 /// A STARK proof for a multi-circuit system.
 #[derive(Serialize, Deserialize)]
-pub struct Proof {
-    pub commitments: Commitments,
+#[serde(bound = "")]
+pub struct Proof<SC: StarkGenericConfig> {
+    pub commitments: Commitments<Com<SC>>,
     /// Per-circuit intermediate accumulator values for the lookup argument.
-    pub intermediate_accumulators: Vec<ExtVal>,
+    pub intermediate_accumulators: Vec<SC::Challenge>,
     /// Log2 of the trace degree for each circuit.
     pub log_degrees: Vec<u8>,
     /// PCS opening proof covering all rounds.
-    pub opening_proof: PcsProof,
-    pub quotient_opened_values: OpenedValuesForRound<ExtVal>,
-    pub preprocessed_opened_values: Option<OpenedValuesForRound<ExtVal>>,
-    pub stage_1_opened_values: OpenedValuesForRound<ExtVal>,
-    pub stage_2_opened_values: OpenedValuesForRound<ExtVal>,
+    pub opening_proof: PcsProof<SC>,
+    pub quotient_opened_values: OpenedValuesForRound<SC::Challenge>,
+    pub preprocessed_opened_values: Option<OpenedValuesForRound<SC::Challenge>>,
+    pub stage_1_opened_values: OpenedValuesForRound<SC::Challenge>,
+    pub stage_2_opened_values: OpenedValuesForRound<SC::Challenge>,
 }
 
-impl Proof {
+impl<SC: StarkGenericConfig> Proof<SC> {
     fn serde_config() -> Configuration<LittleEndian, Fixint> {
         standard().with_little_endian().with_fixed_int_encoding()
     }
@@ -223,11 +220,20 @@ impl Proof {
     }
 }
 
-impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> System<A> {
+impl<SC, A> System<SC, A>
+where
+    SC: StarkGenericConfig,
+    A: BaseAir<Val<SC>> + for<'a> Air<ProverConstraintFolder<'a, Val<SC>, SC::Challenge>>,
+{
     /// Generates a STARK proof for the system with a single claim.
     ///
     /// This is a convenience wrapper around [`Self::prove_multiple_claims`].
-    pub fn prove(&self, key: &ProverKey, claim: &[Val], witness: SystemWitness) -> Proof {
+    pub fn prove(
+        &self,
+        key: &ProverKey<SC>,
+        claim: &[Val<SC>],
+        witness: SystemWitness<Val<SC>>,
+    ) -> Proof<SC> {
         self.prove_multiple_claims(key, &[claim], witness)
     }
 
@@ -238,10 +244,10 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> Sys
     #[tracing::instrument(level = "info", skip_all, name = "stark/prove")]
     pub fn prove_multiple_claims(
         &self,
-        key: &ProverKey,
-        claims: &[&[Val]],
-        witness: SystemWitness,
-    ) -> Proof {
+        key: &ProverKey<SC>,
+        claims: &[&[Val<SC>]],
+        witness: SystemWitness<Val<SC>>,
+    ) -> Proof<SC> {
         // initialize pcs and challenger
         let pcs = self.config.pcs();
         let mut challenger = self.config.initialise_challenger();
@@ -257,17 +263,15 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> Sys
         let evaluations = witness.traces.into_iter().map(|trace| {
             let degree = trace.height();
             let log_degree = log2_strict_usize(degree);
-            let trace_domain =
-                <Pcs as PcsTrait<ExtVal, Challenger>>::natural_domain_for_degree(pcs, degree);
+            let trace_domain = pcs.natural_domain_for_degree(degree);
             log_degrees.push(log_degree);
             (trace_domain, trace)
         });
-        let (stage_1_trace_commit, stage_1_trace_data) =
-            <Pcs as PcsTrait<ExtVal, Challenger>>::commit(pcs, evaluations);
+        let (stage_1_trace_commit, stage_1_trace_data) = pcs.commit(evaluations);
         drop(_g);
 
         if let Some(commit) = &self.preprocessed_commit {
-            challenger.observe(commit);
+            challenger.observe(commit.clone());
         }
         challenger.observe(stage_1_trace_commit.clone());
 
@@ -275,27 +279,27 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> Sys
         // sizes; the verifier reads these from the (untrusted) proof, so they
         // must influence every subsequent challenge.
         for log_degree in &log_degrees {
-            challenger.observe(Val::from_usize(*log_degree));
+            challenger.observe(Val::<SC>::from_usize(*log_degree));
         }
 
         // Observe the claims, length-prefixed so that distinct claim
         // structures (e.g. [[a, b]] vs [[a], [b]]) yield distinct transcripts.
         // This has to be done before generating the lookup argument challenge,
         // otherwise the lookup argument can be attacked.
-        challenger.observe(Val::from_usize(claims.len()));
+        challenger.observe(Val::<SC>::from_usize(claims.len()));
         for claim in claims {
-            challenger.observe(Val::from_usize(claim.len()));
+            challenger.observe(Val::<SC>::from_usize(claim.len()));
             challenger.observe_slice(claim);
         }
 
         // generate lookup challenges
-        let lookup_argument_challenge: ExtVal = challenger.sample_algebra_element();
+        let lookup_argument_challenge: SC::Challenge = challenger.sample_algebra_element();
         challenger.observe_algebra_element(lookup_argument_challenge);
-        let fingerprint_challenge: ExtVal = challenger.sample_algebra_element();
+        let fingerprint_challenge: SC::Challenge = challenger.sample_algebra_element();
         challenger.observe_algebra_element(fingerprint_challenge);
 
         // construct the accumulator from the claims
-        let mut acc = ExtVal::ZERO;
+        let mut acc = SC::Challenge::ZERO;
         for claim in claims {
             let message = lookup_argument_challenge
                 + fingerprint(&fingerprint_challenge, claim.iter().cloned());
@@ -318,12 +322,10 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> Sys
         let _g = tracing::info_span!("stark/stage2_commit").entered();
         let evaluations = stage_2_traces.into_iter().map(|trace| {
             let degree = trace.height();
-            let trace_domain =
-                <Pcs as PcsTrait<ExtVal, Challenger>>::natural_domain_for_degree(pcs, degree);
+            let trace_domain = pcs.natural_domain_for_degree(degree);
             (trace_domain, trace.flatten_to_base())
         });
-        let (stage_2_trace_commit, stage_2_trace_data) =
-            <Pcs as PcsTrait<ExtVal, Challenger>>::commit(pcs, evaluations);
+        let (stage_2_trace_commit, stage_2_trace_data) = pcs.commit(evaluations);
         drop(_g);
         challenger.observe(stage_2_trace_commit.clone());
 
@@ -335,7 +337,7 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> Sys
         }
 
         // generate constraint challenge
-        let constraint_challenge: ExtVal = challenger.sample_algebra_element();
+        let constraint_challenge: SC::Challenge = challenger.sample_algebra_element();
 
         // Cost: "Quotient computation and commit" — constraint evaluation on the
         // quotient domain (Σ n_i·q_i·eval_cost(k_i)) plus LDE + Merkle of the
@@ -354,10 +356,7 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> Sys
                 let air = &circuit.air;
                 let quotient_degree = circuit.quotient_degree();
                 let log_quotient_degree = log2_strict_usize(quotient_degree);
-                let trace_domain = <Pcs as PcsTrait<ExtVal, Challenger>>::natural_domain_for_degree(
-                    pcs,
-                    1 << log_degree,
-                );
+                let trace_domain = pcs.natural_domain_for_degree(1 << log_degree);
                 let quotient_domain =
                     trace_domain.create_disjoint_domain(1 << (log_degree + log_quotient_degree));
                 let preprocessed_trace_on_quotient_domain = key
@@ -365,36 +364,25 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> Sys
                     .as_ref()
                     .zip(self.preprocessed_indices[idx])
                     .map(|(preprocessed_trace_data, preprocessed_idx)| {
-                        <Pcs as PcsTrait<ExtVal, Challenger>>::get_evaluations_on_domain(
-                            pcs,
+                        pcs.get_evaluations_on_domain(
                             preprocessed_trace_data,
                             preprocessed_idx,
                             quotient_domain,
                         )
                     });
                 let stage_1_trace_on_quotient_domain =
-                    <Pcs as PcsTrait<ExtVal, Challenger>>::get_evaluations_on_domain(
-                        pcs,
-                        &stage_1_trace_data,
-                        idx,
-                        quotient_domain,
-                    );
+                    pcs.get_evaluations_on_domain(&stage_1_trace_data, idx, quotient_domain);
                 let stage_2_trace_on_quotient_domain =
-                    <Pcs as PcsTrait<ExtVal, Challenger>>::get_evaluations_on_domain(
-                        pcs,
-                        &stage_2_trace_data,
-                        idx,
-                        quotient_domain,
-                    );
+                    pcs.get_evaluations_on_domain(&stage_2_trace_data, idx, quotient_domain);
                 // compute the quotient values which are elements of the extension field and flatten it to the base field
-                let public_values = [];
+                let public_values: [Val<SC>; 0] = [];
                 let stage_2_public_values = [
                     lookup_argument_challenge,
                     fingerprint_challenge,
                     acc,
                     *next_acc,
                 ];
-                let quotient_values = quotient_values(
+                let quotient_values = quotient_values::<SC, _>(
                     air,
                     &public_values,
                     &stage_2_public_values,
@@ -407,7 +395,7 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> Sys
                     circuit.constraint_count,
                 );
                 let quotient_flat =
-                    RowMajorMatrix::new_col(quotient_values).flatten_to_base::<Val>();
+                    RowMajorMatrix::new_col(quotient_values).flatten_to_base::<Val<SC>>();
                 // note that, in general, the quotients have a degree that is greater than the trace polynomials,
                 // so for FRI to work so we must split into smaller polynomials
                 let quotient_sub_evaluations =
@@ -420,8 +408,7 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> Sys
                     .into_iter()
                     .zip(quotient_sub_evaluations)
             });
-        let (quotient_commit, quotient_data) =
-            <Pcs as PcsTrait<ExtVal, Challenger>>::commit(pcs, quotient_evaluations);
+        let (quotient_commit, quotient_data) = pcs.commit(quotient_evaluations);
         challenger.observe(quotient_commit.clone());
         drop(_g);
 
@@ -435,7 +422,7 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> Sys
         // Cost: "FRI opening" — barycentric interpolation (Σ n_i·B·W_i),
         // FRI folding (≈ H), and FRI queries (Q·R·log₂ H hash ops).
         let _g = tracing::info_span!("stark/fri_open").entered();
-        let zeta: ExtVal = challenger.sample_algebra_element();
+        let zeta: SC::Challenge = challenger.sample_algebra_element();
         let mut round0_openings = vec![];
         let mut round1_openings = vec![];
         let mut round2_openings = vec![];
@@ -443,10 +430,7 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> Sys
         for i in 0..self.circuits.len() {
             let log_degree = log_degrees[i];
             let quotient_degree = quotient_degrees[i];
-            let trace_domain = <Pcs as PcsTrait<ExtVal, Challenger>>::natural_domain_for_degree(
-                pcs,
-                1 << log_degree,
-            );
+            let trace_domain = pcs.natural_domain_for_degree(1 << log_degree);
             let zeta_next = trace_domain
                 .next_point(zeta)
                 .expect("domain has no next point");
@@ -491,20 +475,21 @@ impl<A: BaseAir<Val> + for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>> Sys
 }
 
 #[allow(clippy::too_many_arguments)]
-fn quotient_values<A>(
+fn quotient_values<SC, A>(
     air: &A,
-    public_values: &[Val],
-    stage_2_public_values: &[ExtVal],
-    trace_domain: Domain,
-    quotient_domain: Domain,
-    preprocessed_on_quotient_domain: &Option<EvaluationsOnDomain<'_>>,
-    stage_1_on_quotient_domain: &EvaluationsOnDomain<'_>,
-    stage_2_on_quotient_domain: &EvaluationsOnDomain<'_>,
-    alpha: ExtVal,
+    public_values: &[Val<SC>],
+    stage_2_public_values: &[SC::Challenge],
+    trace_domain: Domain<SC>,
+    quotient_domain: Domain<SC>,
+    preprocessed_on_quotient_domain: &Option<EvaluationsOnDomain<'_, SC>>,
+    stage_1_on_quotient_domain: &EvaluationsOnDomain<'_, SC>,
+    stage_2_on_quotient_domain: &EvaluationsOnDomain<'_, SC>,
+    alpha: SC::Challenge,
     constraint_count: usize,
-) -> Vec<ExtVal>
+) -> Vec<SC::Challenge>
 where
-    A: for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>,
+    SC: StarkGenericConfig,
+    A: for<'a> Air<ProverConstraintFolder<'a, Val<SC>, SC::Challenge>>,
 {
     let quotient_size = quotient_domain.size();
     let stage_1_width = stage_1_on_quotient_domain.width();
@@ -517,17 +502,18 @@ where
     let qdb = log2_strict_usize(quotient_domain.size()) - log2_strict_usize(trace_domain.size());
     let next_step = 1 << qdb;
 
-    for _ in quotient_size..PackedVal::WIDTH {
-        sels.is_first_row.push(Val::default());
-        sels.is_last_row.push(Val::default());
-        sels.is_transition.push(Val::default());
-        sels.inv_vanishing.push(Val::default());
+    for _ in quotient_size..PackedVal::<SC>::WIDTH {
+        sels.is_first_row.push(Val::<SC>::default());
+        sels.is_last_row.push(Val::<SC>::default());
+        sels.is_transition.push(Val::<SC>::default());
+        sels.inv_vanishing.push(Val::<SC>::default());
     }
 
     let mut alpha_powers = alpha.powers().collect_n(constraint_count);
     alpha_powers.reverse();
 
-    let decomposed_alpha_powers: Vec<_> = (0..<ExtVal as BasedVectorSpace<Val>>::DIMENSION)
+    let decomposed_alpha_powers: Vec<_> = (0
+        ..<SC::Challenge as BasedVectorSpace<Val<SC>>>::DIMENSION)
         .map(|i| {
             alpha_powers
                 .iter()
@@ -539,9 +525,9 @@ where
     {
         (0..quotient_size)
             .into_par_iter()
-            .step_by(PackedVal::WIDTH)
+            .step_by(PackedVal::<SC>::WIDTH)
             .flat_map_iter(|i_start| {
-                quotient_values_inner(
+                quotient_values_inner::<SC, A>(
                     air,
                     public_values,
                     stage_2_public_values,
@@ -564,9 +550,9 @@ where
     #[cfg(not(feature = "parallel"))]
     {
         (0..quotient_size)
-            .step_by(PackedVal::WIDTH)
+            .step_by(PackedVal::<SC>::WIDTH)
             .flat_map_iter(|i_start| {
-                quotient_values_inner(
+                quotient_values_inner::<SC, A>(
                     air,
                     public_values,
                     stage_2_public_values,
@@ -589,32 +575,33 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-fn quotient_values_inner<A>(
+fn quotient_values_inner<SC, A>(
     air: &A,
-    stage_1_public_values: &[Val],
-    stage_2_public_values: &[ExtVal],
-    sels: &LagrangeSelectors<Vec<Val>>,
+    stage_1_public_values: &[Val<SC>],
+    stage_2_public_values: &[SC::Challenge],
+    sels: &LagrangeSelectors<Vec<Val<SC>>>,
     quotient_size: usize,
-    preprocessed_on_quotient_domain: &Option<EvaluationsOnDomain<'_>>,
-    stage_1_on_quotient_domain: &EvaluationsOnDomain<'_>,
-    stage_2_on_quotient_domain: &EvaluationsOnDomain<'_>,
+    preprocessed_on_quotient_domain: &Option<EvaluationsOnDomain<'_, SC>>,
+    stage_1_on_quotient_domain: &EvaluationsOnDomain<'_, SC>,
+    stage_2_on_quotient_domain: &EvaluationsOnDomain<'_, SC>,
     stage_1_width: usize,
     stage_2_width: usize,
     preprocessed_width: usize,
-    alpha_powers: &[BinomialExtensionField<Val, 2>],
-    decomposed_alpha_powers: &[Vec<Val>],
+    alpha_powers: &[SC::Challenge],
+    decomposed_alpha_powers: &[Vec<Val<SC>>],
     next_step: usize,
     i_start: usize,
-) -> impl Iterator<Item = BinomialExtensionField<Val, 2>>
+) -> impl Iterator<Item = SC::Challenge>
 where
-    A: for<'a> Air<ProverConstraintFolder<'a, Val, ExtVal>>,
+    SC: StarkGenericConfig,
+    A: for<'a> Air<ProverConstraintFolder<'a, Val<SC>, SC::Challenge>>,
 {
-    let i_range = i_start..i_start + PackedVal::WIDTH;
+    let i_range = i_start..i_start + PackedVal::<SC>::WIDTH;
 
-    let is_first_row = *PackedVal::from_slice(&sels.is_first_row[i_range.clone()]);
-    let is_last_row = *PackedVal::from_slice(&sels.is_last_row[i_range.clone()]);
-    let is_transition = *PackedVal::from_slice(&sels.is_transition[i_range.clone()]);
-    let inv_vanishing = *PackedVal::from_slice(&sels.inv_vanishing[i_range]);
+    let is_first_row = *PackedVal::<SC>::from_slice(&sels.is_first_row[i_range.clone()]);
+    let is_last_row = *PackedVal::<SC>::from_slice(&sels.is_last_row[i_range.clone()]);
+    let is_transition = *PackedVal::<SC>::from_slice(&sels.is_transition[i_range.clone()]);
+    let inv_vanishing = *PackedVal::<SC>::from_slice(&sels.inv_vanishing[i_range]);
 
     let preprocessed = preprocessed_on_quotient_domain
         .as_ref()
@@ -625,24 +612,25 @@ where
             )
         });
     let stage_1 = RowMajorMatrix::new(
-        stage_1_on_quotient_domain.vertically_packed_row_pair::<PackedVal>(i_start, next_step),
+        stage_1_on_quotient_domain.vertically_packed_row_pair::<PackedVal<SC>>(i_start, next_step),
         stage_1_width,
     );
-    let extension_d = <PackedExtVal as BasedVectorSpace<PackedVal>>::DIMENSION;
+    let extension_d = <PackedChallenge<SC> as BasedVectorSpace<PackedVal<SC>>>::DIMENSION;
     let stage_2 = RowMajorMatrix::new(
-        pack(
+        pack::<SC>(
             stage_2_on_quotient_domain.width(),
-            stage_2_on_quotient_domain.wrapping_row_slices(i_start, PackedVal::WIDTH),
+            stage_2_on_quotient_domain.wrapping_row_slices(i_start, PackedVal::<SC>::WIDTH),
         )
-        .chain(pack(
+        .chain(pack::<SC>(
             stage_2_on_quotient_domain.width(),
-            stage_2_on_quotient_domain.wrapping_row_slices(i_start + next_step, PackedVal::WIDTH),
+            stage_2_on_quotient_domain
+                .wrapping_row_slices(i_start + next_step, PackedVal::<SC>::WIDTH),
         ))
         .collect::<Vec<_>>(),
         stage_2_width / extension_d,
     );
 
-    let accumulator = PackedExtVal::ZERO;
+    let accumulator = PackedChallenge::<SC>::ZERO;
     let mut folder = ProverConstraintFolder {
         preprocessed: match preprocessed.as_ref() {
             Some(mat) => RowWindow::from_view(&mat.as_view()),
@@ -664,18 +652,24 @@ where
 
     let quotient = folder.accumulator * inv_vanishing;
 
-    (0..quotient_size.min(PackedVal::WIDTH)).map(move |idx_in_packing| {
-        ExtVal::from_basis_coefficients_fn(|coeff_idx| {
-            <PackedExtVal as BasedVectorSpace<PackedVal>>::as_basis_coefficients_slice(&quotient)
-                [coeff_idx]
+    (0..quotient_size.min(PackedVal::<SC>::WIDTH)).map(move |idx_in_packing| {
+        SC::Challenge::from_basis_coefficients_fn(|coeff_idx| {
+            <PackedChallenge<SC> as BasedVectorSpace<PackedVal<SC>>>::as_basis_coefficients_slice(
+                &quotient,
+            )[coeff_idx]
                 .as_slice()[idx_in_packing]
         })
     })
 }
 
-fn pack(n: usize, rows: Vec<impl Deref<Target = [Val]>>) -> impl Iterator<Item = PackedExtVal> {
-    let extension_d = <PackedExtVal as BasedVectorSpace<PackedVal>>::DIMENSION;
+fn pack<SC: StarkGenericConfig>(
+    n: usize,
+    rows: Vec<impl Deref<Target = [Val<SC>]>>,
+) -> impl Iterator<Item = PackedChallenge<SC>> {
+    let extension_d = <PackedChallenge<SC> as BasedVectorSpace<PackedVal<SC>>>::DIMENSION;
     (0..n).step_by(extension_d).map(move |c| {
-        PackedExtVal::from_basis_coefficients_fn(|j| PackedVal::from_fn(|i| rows[i][c + j]))
+        PackedChallenge::<SC>::from_basis_coefficients_fn(|j| {
+            PackedVal::<SC>::from_fn(|i| rows[i][c + j])
+        })
     })
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,20 +1,19 @@
 use crate::{
     builder::symbolic::{SymbolicAirBuilder, get_max_constraint_degree, get_symbolic_constraints},
+    config::StarkGenericConfig,
     lookup::{LOOKUP_PUBLIC_SIZE, Lookup, LookupAir},
-    types::{
-        Challenger, Commitment, CommitmentParameters, Committer, ExtVal, FriParameters, ProverData,
-        Val,
-    },
+    types::{Challenger, Commitment, ExtVal, GoldilocksKeccakConfig, Pcs, ProverData, Val},
 };
 use p3_air::{Air, BaseAir};
 use p3_challenger::CanObserve;
+use p3_commit::Pcs as PcsTrait;
 use p3_field::PrimeCharacteristicRing;
 use p3_matrix::{Matrix, dense::RowMajorMatrix};
 
 /// A multi-circuit STARK system. Contains all circuits together with their
-/// shared preprocessed commitment and commitment parameters.
+/// shared preprocessed commitment and the protocol configuration.
 pub struct System<A> {
-    pub commitment_parameters: CommitmentParameters,
+    pub config: GoldilocksKeccakConfig,
     pub circuits: Vec<Circuit<A>>,
     /// Commitment to all preprocessed traces (if any circuit has one).
     pub preprocessed_commit: Option<Commitment>,
@@ -32,10 +31,10 @@ pub struct ProverKey {
 impl<A: BaseAir<Val> + Air<SymbolicAirBuilder<Val, ExtVal>>> System<A> {
     #[inline]
     pub fn new(
-        commitment_parameters: CommitmentParameters,
+        config: GoldilocksKeccakConfig,
         airs: impl IntoIterator<Item = LookupAir<A, Val>>,
     ) -> (Self, ProverKey) {
-        let committer = Committer::new(commitment_parameters);
+        let pcs = config.pcs();
         let mut circuits = vec![];
         let mut preprocessed_traces = vec![];
         let mut preprocessed_indices = vec![];
@@ -44,20 +43,24 @@ impl<A: BaseAir<Val> + Air<SymbolicAirBuilder<Val, ExtVal>>> System<A> {
             circuits.push(circuit);
             if let Some(preprocessed_trace) = maybe_preprocessed_trace {
                 preprocessed_indices.push(Some(preprocessed_traces.len()));
-                let domain = committer.natural_domain_for_degree(preprocessed_trace.height());
+                let domain = <Pcs as PcsTrait<ExtVal, Challenger>>::natural_domain_for_degree(
+                    pcs,
+                    preprocessed_trace.height(),
+                );
                 preprocessed_traces.push((domain, preprocessed_trace));
             } else {
                 preprocessed_indices.push(None);
             }
         }
         let (preprocessed_commit, preprocessed_data) = if !preprocessed_traces.is_empty() {
-            let (commit, data) = committer.commit(preprocessed_traces);
+            let (commit, data) =
+                <Pcs as PcsTrait<ExtVal, Challenger>>::commit(pcs, preprocessed_traces);
             (Some(commit), Some(data))
         } else {
             (None, None)
         };
         let system = Self {
-            commitment_parameters,
+            config,
             circuits,
             preprocessed_commit,
             preprocessed_indices,
@@ -68,19 +71,14 @@ impl<A: BaseAir<Val> + Air<SymbolicAirBuilder<Val, ExtVal>>> System<A> {
 }
 
 impl<A> System<A> {
-    /// Binds the protocol parameters and the system shape into the Fiat-Shamir
-    /// transcript. The prover and the verifier must call this identically,
-    /// before observing any commitment, so that transcripts of systems with
-    /// different parameters or circuit shapes never collide.
-    pub fn observe_shape(&self, fri_parameters: &FriParameters, challenger: &mut Challenger) {
+    /// Binds the system shape into the Fiat-Shamir transcript. The prover and
+    /// the verifier must call this identically, before observing any
+    /// commitment, so that transcripts of systems with different circuit
+    /// shapes never collide. The protocol parameters are bound separately,
+    /// via the challenger seed (see
+    /// [`StarkGenericConfig::initialise_challenger`]).
+    pub fn observe_shape(&self, challenger: &mut Challenger) {
         let mut observe_usize = |x: usize| challenger.observe(Val::from_usize(x));
-        observe_usize(self.commitment_parameters.log_blowup);
-        observe_usize(self.commitment_parameters.cap_height);
-        observe_usize(fri_parameters.log_final_poly_len);
-        observe_usize(fri_parameters.max_log_arity);
-        observe_usize(fri_parameters.num_queries);
-        observe_usize(fri_parameters.commit_proof_of_work_bits);
-        observe_usize(fri_parameters.query_proof_of_work_bits);
         observe_usize(self.circuits.len());
         for circuit in &self.circuits {
             observe_usize(circuit.constraint_count);
@@ -217,6 +215,7 @@ impl<A: BaseAir<Val> + Air<SymbolicAirBuilder<Val, ExtVal>>> Circuit<A> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::{CommitmentParameters, FriParameters};
     use p3_air::AirBuilder;
 
     /// A trivial AIR with a preprocessed trace of 4 rows and no constraints.
@@ -246,10 +245,15 @@ mod tests {
             log_blowup: 1,
             cap_height: 0,
         };
-        let (system, _key) = System::new(
-            commitment_parameters,
-            [LookupAir::new(Preprocessed, vec![])],
-        );
+        let fri_parameters = FriParameters {
+            log_final_poly_len: 0,
+            max_log_arity: 1,
+            num_queries: 64,
+            commit_proof_of_work_bits: 0,
+            query_proof_of_work_bits: 0,
+        };
+        let config = GoldilocksKeccakConfig::new(commitment_parameters, fri_parameters);
+        let (system, _key) = System::new(config, [LookupAir::new(Preprocessed, vec![])]);
         // The main trace has 8 rows but the preprocessed trace has 4. This
         // must panic instead of silently truncating the lookup rows.
         let trace = RowMajorMatrix::new(vec![Val::ZERO; 8], 1);

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,60 +1,59 @@
 use crate::{
     builder::symbolic::{SymbolicAirBuilder, get_max_constraint_degree, get_symbolic_constraints},
-    config::StarkGenericConfig,
+    config::{Com, PcsData, StarkGenericConfig, Val},
     lookup::{LOOKUP_PUBLIC_SIZE, Lookup, LookupAir},
-    types::{Challenger, Commitment, ExtVal, GoldilocksKeccakConfig, Pcs, ProverData, Val},
 };
 use p3_air::{Air, BaseAir};
 use p3_challenger::CanObserve;
-use p3_commit::Pcs as PcsTrait;
-use p3_field::PrimeCharacteristicRing;
+use p3_commit::{Pcs, PolynomialSpace};
+use p3_field::{ExtensionField, Field, PrimeCharacteristicRing};
 use p3_matrix::{Matrix, dense::RowMajorMatrix};
 
 /// A multi-circuit STARK system. Contains all circuits together with their
 /// shared preprocessed commitment and the protocol configuration.
-pub struct System<A> {
-    pub config: GoldilocksKeccakConfig,
-    pub circuits: Vec<Circuit<A>>,
+pub struct System<SC: StarkGenericConfig, A> {
+    pub config: SC,
+    pub circuits: Vec<Circuit<A, Val<SC>>>,
     /// Commitment to all preprocessed traces (if any circuit has one).
-    pub preprocessed_commit: Option<Commitment>,
+    pub preprocessed_commit: Option<Com<SC>>,
     /// Maps each circuit index to its position within the preprocessed commitment.
     /// `None` if that circuit has no preprocessed trace.
     pub preprocessed_indices: Vec<Option<usize>>,
 }
 
 /// Prover-side data that must be retained between system setup and proving.
-pub struct ProverKey {
+pub struct ProverKey<SC: StarkGenericConfig> {
     /// PCS prover data for the preprocessed traces.
-    pub preprocessed_data: Option<ProverData>,
+    pub preprocessed_data: Option<PcsData<SC>>,
 }
 
-impl<A: BaseAir<Val> + Air<SymbolicAirBuilder<Val, ExtVal>>> System<A> {
+impl<SC, A> System<SC, A>
+where
+    SC: StarkGenericConfig,
+    A: BaseAir<Val<SC>> + Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>>,
+{
     #[inline]
     pub fn new(
-        config: GoldilocksKeccakConfig,
-        airs: impl IntoIterator<Item = LookupAir<A, Val>>,
-    ) -> (Self, ProverKey) {
+        config: SC,
+        airs: impl IntoIterator<Item = LookupAir<A, Val<SC>>>,
+    ) -> (Self, ProverKey<SC>) {
         let pcs = config.pcs();
         let mut circuits = vec![];
         let mut preprocessed_traces = vec![];
         let mut preprocessed_indices = vec![];
         for air in airs {
-            let (circuit, maybe_preprocessed_trace) = Circuit::from_air(air);
+            let (circuit, maybe_preprocessed_trace) = Circuit::from_air::<SC::Challenge>(air);
             circuits.push(circuit);
             if let Some(preprocessed_trace) = maybe_preprocessed_trace {
                 preprocessed_indices.push(Some(preprocessed_traces.len()));
-                let domain = <Pcs as PcsTrait<ExtVal, Challenger>>::natural_domain_for_degree(
-                    pcs,
-                    preprocessed_trace.height(),
-                );
+                let domain = pcs.natural_domain_for_degree(preprocessed_trace.height());
                 preprocessed_traces.push((domain, preprocessed_trace));
             } else {
                 preprocessed_indices.push(None);
             }
         }
         let (preprocessed_commit, preprocessed_data) = if !preprocessed_traces.is_empty() {
-            let (commit, data) =
-                <Pcs as PcsTrait<ExtVal, Challenger>>::commit(pcs, preprocessed_traces);
+            let (commit, data) = pcs.commit(preprocessed_traces);
             (Some(commit), Some(data))
         } else {
             (None, None)
@@ -70,15 +69,15 @@ impl<A: BaseAir<Val> + Air<SymbolicAirBuilder<Val, ExtVal>>> System<A> {
     }
 }
 
-impl<A> System<A> {
+impl<SC: StarkGenericConfig, A> System<SC, A> {
     /// Binds the system shape into the Fiat-Shamir transcript. The prover and
     /// the verifier must call this identically, before observing any
     /// commitment, so that transcripts of systems with different circuit
     /// shapes never collide. The protocol parameters are bound separately,
     /// via the challenger seed (see
     /// [`StarkGenericConfig::initialise_challenger`]).
-    pub fn observe_shape(&self, challenger: &mut Challenger) {
-        let mut observe_usize = |x: usize| challenger.observe(Val::from_usize(x));
+    pub fn observe_shape(&self, challenger: &mut SC::Challenger) {
+        let mut observe_usize = |x: usize| challenger.observe(Val::<SC>::from_usize(x));
         observe_usize(self.circuits.len());
         for circuit in &self.circuits {
             observe_usize(circuit.constraint_count);
@@ -93,8 +92,8 @@ impl<A> System<A> {
 
 /// A single circuit within the system, wrapping an AIR together with
 /// precomputed metadata used by the prover and verifier.
-pub struct Circuit<A> {
-    pub air: LookupAir<A, Val>,
+pub struct Circuit<A, F: Field> {
+    pub air: LookupAir<A, F>,
     pub constraint_count: usize,
     pub max_constraint_degree: usize,
     pub preprocessed_height: usize,
@@ -103,7 +102,7 @@ pub struct Circuit<A> {
     pub stage_2_width: usize,
 }
 
-impl<A> Circuit<A> {
+impl<A, F: Field> Circuit<A, F> {
     /// Degree of the quotient polynomial as a multiple of the trace degree.
     /// Division by the vanishing polynomial reduces the composition
     /// polynomial's degree by 1; the result is padded to a power of two so
@@ -116,14 +115,14 @@ impl<A> Circuit<A> {
 /// Witness data for the multi-circuit system, comprising stage 1 traces and
 /// the concrete lookup values derived from them.
 #[derive(Clone)]
-pub struct SystemWitness {
+pub struct SystemWitness<F: Field> {
     /// Stage 1 (main) execution traces, one per circuit.
-    pub traces: Vec<RowMajorMatrix<Val>>,
+    pub traces: Vec<RowMajorMatrix<F>>,
     /// Lookup values per circuit, per row, per lookup.
-    pub lookups: Vec<Vec<Vec<Lookup<Val>>>>,
+    pub lookups: Vec<Vec<Vec<Lookup<F>>>>,
 }
 
-impl SystemWitness {
+impl<F: Field> SystemWitness<F> {
     /// Builds the witness from the stage 1 traces, computing the concrete
     /// lookup values for each row of each circuit.
     ///
@@ -132,7 +131,11 @@ impl SystemWitness {
     /// if a circuit with a preprocessed trace receives a main trace of a
     /// different height (both traces are opened on the same domain, so their
     /// heights must match; the rows would otherwise be silently truncated).
-    pub fn from_stage_1<A>(traces: Vec<RowMajorMatrix<Val>>, system: &System<A>) -> Self {
+    pub fn from_stage_1<SC, A>(traces: Vec<RowMajorMatrix<F>>, system: &System<SC, A>) -> Self
+    where
+        SC: StarkGenericConfig,
+        SC::Pcs: Pcs<SC::Challenge, SC::Challenger, Domain: PolynomialSpace<Val = F>>,
+    {
         assert_eq!(
             traces.len(),
             system.circuits.len(),
@@ -180,8 +183,12 @@ impl SystemWitness {
     }
 }
 
-impl<A: BaseAir<Val> + Air<SymbolicAirBuilder<Val, ExtVal>>> Circuit<A> {
-    pub fn from_air(air: LookupAir<A, Val>) -> (Self, Option<RowMajorMatrix<Val>>) {
+impl<A, F: Field> Circuit<A, F> {
+    pub fn from_air<EF>(air: LookupAir<A, F>) -> (Self, Option<RowMajorMatrix<F>>)
+    where
+        EF: ExtensionField<F>,
+        A: BaseAir<F> + Air<SymbolicAirBuilder<F, EF>>,
+    {
         // as of now, we assume no public values apart from the lookup values
         let io_size = 0;
         let stage_1_width = air.inner_air.width();
@@ -189,7 +196,7 @@ impl<A: BaseAir<Val> + Air<SymbolicAirBuilder<Val, ExtVal>>> Circuit<A> {
         let preprocessed_trace = air.preprocessed_trace();
         let preprocessed_height = preprocessed_trace.as_ref().map_or(0, |mat| mat.height());
         let preprocessed_width = preprocessed_trace.as_ref().map_or(0, |mat| mat.width());
-        let symbolic_constraints = get_symbolic_constraints::<Val, ExtVal, _>(
+        let symbolic_constraints = get_symbolic_constraints::<F, EF, _>(
             &air,
             preprocessed_width,
             stage_1_width,
@@ -215,13 +222,13 @@ impl<A: BaseAir<Val> + Air<SymbolicAirBuilder<Val, ExtVal>>> Circuit<A> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{CommitmentParameters, FriParameters};
+    use crate::types::{CommitmentParameters, FriParameters, GoldilocksKeccakConfig, Val};
     use p3_air::AirBuilder;
 
     /// A trivial AIR with a preprocessed trace of 4 rows and no constraints.
     struct Preprocessed;
 
-    impl<F: p3_field::Field> BaseAir<F> for Preprocessed {
+    impl<F: Field> BaseAir<F> for Preprocessed {
         fn width(&self) -> usize {
             1
         }
@@ -233,7 +240,7 @@ mod tests {
 
     impl<AB: AirBuilder> Air<AB> for Preprocessed
     where
-        AB::F: p3_field::Field,
+        AB::F: Field,
     {
         fn eval(&self, _builder: &mut AB) {}
     }

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,9 +1,13 @@
 use crate::{
     builder::symbolic::{SymbolicAirBuilder, get_max_constraint_degree, get_symbolic_constraints},
     lookup::{LOOKUP_PUBLIC_SIZE, Lookup, LookupAir},
-    types::{Commitment, CommitmentParameters, Committer, ProverData, Val},
+    types::{
+        Challenger, Commitment, CommitmentParameters, Committer, FriParameters, ProverData, Val,
+    },
 };
 use p3_air::{Air, BaseAir};
+use p3_challenger::CanObserve;
+use p3_field::PrimeCharacteristicRing;
 use p3_matrix::{Matrix, dense::RowMajorMatrix};
 
 /// A multi-circuit STARK system. Contains all circuits together with their
@@ -59,6 +63,32 @@ impl<A: BaseAir<Val> + Air<SymbolicAirBuilder>> System<A> {
         };
         let key = ProverKey { preprocessed_data };
         (system, key)
+    }
+}
+
+impl<A> System<A> {
+    /// Binds the protocol parameters and the system shape into the Fiat-Shamir
+    /// transcript. The prover and the verifier must call this identically,
+    /// before observing any commitment, so that transcripts of systems with
+    /// different parameters or circuit shapes never collide.
+    pub fn observe_shape(&self, fri_parameters: &FriParameters, challenger: &mut Challenger) {
+        let mut observe_usize = |x: usize| challenger.observe(Val::from_usize(x));
+        observe_usize(self.commitment_parameters.log_blowup);
+        observe_usize(self.commitment_parameters.cap_height);
+        observe_usize(fri_parameters.log_final_poly_len);
+        observe_usize(fri_parameters.max_log_arity);
+        observe_usize(fri_parameters.num_queries);
+        observe_usize(fri_parameters.commit_proof_of_work_bits);
+        observe_usize(fri_parameters.query_proof_of_work_bits);
+        observe_usize(self.circuits.len());
+        for circuit in &self.circuits {
+            observe_usize(circuit.constraint_count);
+            observe_usize(circuit.max_constraint_degree);
+            observe_usize(circuit.preprocessed_height);
+            observe_usize(circuit.preprocessed_width);
+            observe_usize(circuit.stage_1_width);
+            observe_usize(circuit.stage_2_width);
+        }
     }
 }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -104,6 +104,16 @@ pub struct Circuit<A> {
     pub stage_2_width: usize,
 }
 
+impl<A> Circuit<A> {
+    /// Degree of the quotient polynomial as a multiple of the trace degree.
+    /// Division by the vanishing polynomial reduces the composition
+    /// polynomial's degree by 1; the result is padded to a power of two so
+    /// the quotient can be split into equally-sized chunks.
+    pub fn quotient_degree(&self) -> usize {
+        (self.max_constraint_degree.max(2) - 1).next_power_of_two()
+    }
+}
+
 /// Witness data for the multi-circuit system, comprising stage 1 traces and
 /// the concrete lookup values derived from them.
 #[derive(Clone)]

--- a/src/system.rs
+++ b/src/system.rs
@@ -33,7 +33,7 @@ impl<A: BaseAir<Val> + Air<SymbolicAirBuilder<Val, ExtVal>>> System<A> {
     #[inline]
     pub fn new(
         commitment_parameters: CommitmentParameters,
-        airs: impl IntoIterator<Item = LookupAir<A>>,
+        airs: impl IntoIterator<Item = LookupAir<A, Val>>,
     ) -> (Self, ProverKey) {
         let committer = Committer::new(commitment_parameters);
         let mut circuits = vec![];
@@ -96,7 +96,7 @@ impl<A> System<A> {
 /// A single circuit within the system, wrapping an AIR together with
 /// precomputed metadata used by the prover and verifier.
 pub struct Circuit<A> {
-    pub air: LookupAir<A>,
+    pub air: LookupAir<A, Val>,
     pub constraint_count: usize,
     pub max_constraint_degree: usize,
     pub preprocessed_height: usize,
@@ -183,7 +183,7 @@ impl SystemWitness {
 }
 
 impl<A: BaseAir<Val> + Air<SymbolicAirBuilder<Val, ExtVal>>> Circuit<A> {
-    pub fn from_air(air: LookupAir<A>) -> (Self, Option<RowMajorMatrix<Val>>) {
+    pub fn from_air(air: LookupAir<A, Val>) -> (Self, Option<RowMajorMatrix<Val>>) {
         // as of now, we assume no public values apart from the lookup values
         let io_size = 0;
         let stage_1_width = air.inner_air.width();

--- a/src/system.rs
+++ b/src/system.rs
@@ -115,12 +115,31 @@ pub struct SystemWitness {
 }
 
 impl SystemWitness {
+    /// Builds the witness from the stage 1 traces, computing the concrete
+    /// lookup values for each row of each circuit.
+    ///
+    /// # Panics
+    /// Panics if the number of traces differs from the number of circuits, or
+    /// if a circuit with a preprocessed trace receives a main trace of a
+    /// different height (both traces are opened on the same domain, so their
+    /// heights must match; the rows would otherwise be silently truncated).
     pub fn from_stage_1<A>(traces: Vec<RowMajorMatrix<Val>>, system: &System<A>) -> Self {
+        assert_eq!(
+            traces.len(),
+            system.circuits.len(),
+            "expected one trace per circuit"
+        );
         let lookups = traces
             .iter()
             .zip(system.circuits.iter())
-            .map(|(trace, circuit)| {
+            .enumerate()
+            .map(|(circuit_idx, (trace, circuit))| {
                 if let Some(preprocessed) = &circuit.air.preprocessed {
+                    assert_eq!(
+                        trace.height(),
+                        preprocessed.height(),
+                        "circuit {circuit_idx}: main trace height must equal preprocessed trace height"
+                    );
                     trace
                         .row_slices()
                         .zip(preprocessed.row_slices())
@@ -181,5 +200,48 @@ impl<A: BaseAir<Val> + Air<SymbolicAirBuilder>> Circuit<A> {
             stage_2_width,
         };
         (circuit, preprocessed_trace)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p3_air::AirBuilder;
+
+    /// A trivial AIR with a preprocessed trace of 4 rows and no constraints.
+    struct Preprocessed;
+
+    impl<F: p3_field::Field> BaseAir<F> for Preprocessed {
+        fn width(&self) -> usize {
+            1
+        }
+
+        fn preprocessed_trace(&self) -> Option<RowMajorMatrix<F>> {
+            Some(RowMajorMatrix::new(vec![F::ZERO; 4], 1))
+        }
+    }
+
+    impl<AB: AirBuilder> Air<AB> for Preprocessed
+    where
+        AB::F: p3_field::Field,
+    {
+        fn eval(&self, _builder: &mut AB) {}
+    }
+
+    #[test]
+    #[should_panic(expected = "preprocessed trace height")]
+    fn mismatched_preprocessed_height_panics() {
+        let commitment_parameters = CommitmentParameters {
+            log_blowup: 1,
+            cap_height: 0,
+        };
+        let (system, _key) = System::new(
+            commitment_parameters,
+            [LookupAir::new(Preprocessed, vec![])],
+        );
+        // The main trace has 8 rows but the preprocessed trace has 4. This
+        // must panic instead of silently truncating the lookup rows.
+        let trace = RowMajorMatrix::new(vec![Val::ZERO; 8], 1);
+        SystemWitness::from_stage_1(vec![trace], &system);
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -2,7 +2,8 @@ use crate::{
     builder::symbolic::{SymbolicAirBuilder, get_max_constraint_degree, get_symbolic_constraints},
     lookup::{LOOKUP_PUBLIC_SIZE, Lookup, LookupAir},
     types::{
-        Challenger, Commitment, CommitmentParameters, Committer, FriParameters, ProverData, Val,
+        Challenger, Commitment, CommitmentParameters, Committer, ExtVal, FriParameters, ProverData,
+        Val,
     },
 };
 use p3_air::{Air, BaseAir};
@@ -28,7 +29,7 @@ pub struct ProverKey {
     pub preprocessed_data: Option<ProverData>,
 }
 
-impl<A: BaseAir<Val> + Air<SymbolicAirBuilder>> System<A> {
+impl<A: BaseAir<Val> + Air<SymbolicAirBuilder<Val, ExtVal>>> System<A> {
     #[inline]
     pub fn new(
         commitment_parameters: CommitmentParameters,
@@ -181,7 +182,7 @@ impl SystemWitness {
     }
 }
 
-impl<A: BaseAir<Val> + Air<SymbolicAirBuilder>> Circuit<A> {
+impl<A: BaseAir<Val> + Air<SymbolicAirBuilder<Val, ExtVal>>> Circuit<A> {
     pub fn from_air(air: LookupAir<A>) -> (Self, Option<RowMajorMatrix<Val>>) {
         // as of now, we assume no public values apart from the lookup values
         let io_size = 0;
@@ -190,7 +191,7 @@ impl<A: BaseAir<Val> + Air<SymbolicAirBuilder>> Circuit<A> {
         let preprocessed_trace = air.preprocessed_trace();
         let preprocessed_height = preprocessed_trace.as_ref().map_or(0, |mat| mat.height());
         let preprocessed_width = preprocessed_trace.as_ref().map_or(0, |mat| mat.width());
-        let symbolic_constraints = get_symbolic_constraints(
+        let symbolic_constraints = get_symbolic_constraints::<Val, ExtVal, _>(
             &air,
             preprocessed_width,
             stage_1_width,

--- a/src/system.rs
+++ b/src/system.rs
@@ -41,8 +41,21 @@ where
         let mut circuits = vec![];
         let mut preprocessed_traces = vec![];
         let mut preprocessed_indices = vec![];
-        for air in airs {
+        for (circuit_idx, air) in airs.into_iter().enumerate() {
             let (circuit, maybe_preprocessed_trace) = Circuit::from_air::<SC::Challenge>(air);
+            // The prover obtains trace evaluations on the quotient domain
+            // from the PCS, which can only serve domains up to
+            // `max_quotient_degree` times the trace domain (the blowup
+            // factor for FRI). Beyond that, proving would silently produce
+            // invalid proofs, so reject the circuit upfront.
+            assert!(
+                circuit.quotient_degree() <= config.max_quotient_degree(),
+                "circuit {circuit_idx}: constraint degree {} needs quotient degree {}, but the \
+                 PCS only supports {}; increase log_blowup or lower the constraint degree",
+                circuit.max_constraint_degree,
+                circuit.quotient_degree(),
+                config.max_quotient_degree(),
+            );
             circuits.push(circuit);
             if let Some(preprocessed_trace) = maybe_preprocessed_trace {
                 preprocessed_indices.push(Some(preprocessed_traces.len()));
@@ -223,7 +236,7 @@ impl<A, F: Field> Circuit<A, F> {
 mod tests {
     use super::*;
     use crate::types::{CommitmentParameters, FriParameters, GoldilocksKeccakConfig, Val};
-    use p3_air::AirBuilder;
+    use p3_air::{AirBuilder, WindowAccess};
 
     /// A trivial AIR with a preprocessed trace of 4 rows and no constraints.
     struct Preprocessed;
@@ -243,6 +256,75 @@ mod tests {
         AB::F: Field,
     {
         fn eval(&self, _builder: &mut AB) {}
+    }
+
+    /// A degree-5 constraint: `x^5 == y`.
+    struct HighDegreeAir;
+
+    impl<F> BaseAir<F> for HighDegreeAir {
+        fn width(&self) -> usize {
+            2
+        }
+    }
+
+    impl<AB> Air<AB> for HighDegreeAir
+    where
+        AB: AirBuilder,
+        AB::Var: Copy,
+    {
+        fn eval(&self, builder: &mut AB) {
+            let main = builder.main();
+            let local = main.current_slice();
+            let x = local[0];
+            builder.assert_eq(x * x * x * x * x, local[1]);
+        }
+    }
+
+    /// The prover can only evaluate constraints on a domain `2^log_blowup`
+    /// times the trace domain, so the constraint degree is bounded by
+    /// `2^log_blowup + 1` (degree 3 at `log_blowup = 1`). Exceeding it used
+    /// to silently produce invalid proofs; it must be rejected at setup.
+    #[test]
+    #[should_panic(expected = "needs quotient degree 4, but the PCS only supports 2")]
+    fn excessive_constraint_degree_rejected() {
+        let commitment_parameters = CommitmentParameters {
+            log_blowup: 1,
+            cap_height: 0,
+        };
+        let fri_parameters = FriParameters {
+            log_final_poly_len: 0,
+            max_log_arity: 1,
+            num_queries: 64,
+            commit_proof_of_work_bits: 0,
+            query_proof_of_work_bits: 0,
+        };
+        let config = GoldilocksKeccakConfig::new(commitment_parameters, fri_parameters);
+        System::new(config, [LookupAir::new(HighDegreeAir, vec![])]);
+    }
+
+    /// The same degree-5 circuit is fine at `log_blowup = 2` (quotient
+    /// degree 4 = blowup factor 4), end to end.
+    #[test]
+    fn high_degree_constraint_with_larger_blowup() {
+        let commitment_parameters = CommitmentParameters {
+            log_blowup: 2,
+            cap_height: 0,
+        };
+        let fri_parameters = FriParameters {
+            log_final_poly_len: 0,
+            max_log_arity: 1,
+            num_queries: 40,
+            commit_proof_of_work_bits: 0,
+            query_proof_of_work_bits: 0,
+        };
+        let config = GoldilocksKeccakConfig::new(commitment_parameters, fri_parameters);
+        let (system, key) = System::new(config, [LookupAir::new(HighDegreeAir, vec![])]);
+        let f = Val::from_u32;
+        let trace = RowMajorMatrix::new(vec![f(2), f(32), f(1), f(1), f(3), f(243), f(0), f(0)], 2);
+        let witness = SystemWitness::from_stage_1(vec![trace], &system);
+        let no_claims: &[&[Val]] = &[];
+        let proof = system.prove_multiple_claims(&key, no_claims, witness);
+        system.verify_multiple_claims(no_claims, &proof).unwrap();
     }
 
     #[test]

--- a/src/test_circuits/baby_bear_config.rs
+++ b/src/test_circuits/baby_bear_config.rs
@@ -1,0 +1,190 @@
+//! A second [`StarkGenericConfig`] instantiation — BabyBear field with a
+//! degree-4 binomial extension and Poseidon2 hashing — differing from the
+//! reference Goldilocks/Keccak config in both the field and the hash axes.
+//!
+//! This module exists to prove that the protocol is actually generic: if a
+//! change compiles only for the reference config, the smoke test here
+//! catches it.
+
+use crate::builder::symbolic::{SymbolicExpression, var};
+use crate::config::StarkGenericConfig;
+use crate::lookup::{Lookup, LookupAir};
+use crate::system::{System, SystemWitness};
+use crate::types::{CommitmentParameters, FriParameters};
+use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+use p3_challenger::{CanObserve, DuplexChallenger};
+use p3_commit::ExtensionMmcs;
+use p3_dft::Radix2DitParallel;
+use p3_field::extension::BinomialExtensionField;
+use p3_field::{Field, PrimeCharacteristicRing, TwoAdicField};
+use p3_fri::{FriParameters as InnerFriParameters, TwoAdicFriPcs};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+type Val = BabyBear;
+type Perm = Poseidon2BabyBear<16>;
+type Hash = PaddingFreeSponge<Perm, 16, 8, 8>;
+type Compress = TruncatedPermutation<Perm, 2, 8, 16>;
+type ValMmcs =
+    MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, Hash, Compress, 2, 8>;
+type Challenge = BinomialExtensionField<Val, 4>;
+type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
+type Dft = Radix2DitParallel<Val>;
+type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
+
+struct BabyBearPoseidon2Config {
+    pcs: Pcs,
+    perm: Perm,
+    /// Field elements observed into every fresh challenger: a domain tag
+    /// plus a digest of the protocol parameters (see the transcript contract
+    /// on [`StarkGenericConfig::initialise_challenger`]).
+    challenger_seed: Vec<Val>,
+    max_log_degree: usize,
+}
+
+impl BabyBearPoseidon2Config {
+    fn new(commitment_parameters: CommitmentParameters, fri_parameters: FriParameters) -> Self {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = Hash::new(perm.clone());
+        let compress = Compress::new(perm.clone());
+        let val_mmcs = ValMmcs::new(hash, compress, commitment_parameters.cap_height);
+        let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+        let inner_parameters = InnerFriParameters {
+            log_blowup: commitment_parameters.log_blowup,
+            log_final_poly_len: fri_parameters.log_final_poly_len,
+            max_log_arity: fri_parameters.max_log_arity,
+            num_queries: fri_parameters.num_queries,
+            commit_proof_of_work_bits: fri_parameters.commit_proof_of_work_bits,
+            query_proof_of_work_bits: fri_parameters.query_proof_of_work_bits,
+            mmcs: challenge_mmcs,
+        };
+        let pcs = Pcs::new(Dft::default(), val_mmcs, inner_parameters);
+        let mut challenger_seed: Vec<Val> = b"multi-stark/v0"
+            .iter()
+            .map(|&byte| Val::from_u8(byte))
+            .collect();
+        challenger_seed.extend(
+            [
+                commitment_parameters.log_blowup,
+                commitment_parameters.cap_height,
+                fri_parameters.log_final_poly_len,
+                fri_parameters.max_log_arity,
+                fri_parameters.num_queries,
+                fri_parameters.commit_proof_of_work_bits,
+                fri_parameters.query_proof_of_work_bits,
+            ]
+            .map(Val::from_usize),
+        );
+        let max_log_degree = Val::TWO_ADICITY - commitment_parameters.log_blowup;
+        Self {
+            pcs,
+            perm,
+            challenger_seed,
+            max_log_degree,
+        }
+    }
+}
+
+impl StarkGenericConfig for BabyBearPoseidon2Config {
+    type Pcs = Pcs;
+    type Challenge = Challenge;
+    type Challenger = Challenger;
+
+    fn pcs(&self) -> &Pcs {
+        &self.pcs
+    }
+
+    fn initialise_challenger(&self) -> Challenger {
+        let mut challenger = Challenger::new(self.perm.clone());
+        for value in &self.challenger_seed {
+            challenger.observe(*value);
+        }
+        challenger
+    }
+
+    fn max_log_degree(&self) -> usize {
+        self.max_log_degree
+    }
+}
+
+/// A minimal AIR: enforces `a * b == c` per row, with a self-canceling
+/// push/pull lookup pair to exercise the stage 2 machinery.
+struct MulAir;
+
+impl<F> BaseAir<F> for MulAir {
+    fn width(&self) -> usize {
+        3
+    }
+}
+
+impl<AB> Air<AB> for MulAir
+where
+    AB: AirBuilder,
+    AB::Var: Copy,
+{
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main.current_slice();
+        builder.assert_eq(local[0] * local[1], local[2]);
+    }
+}
+
+fn lookups() -> Vec<Lookup<SymbolicExpression<Val>>> {
+    let one: SymbolicExpression<Val> = Val::ONE.into();
+    vec![
+        Lookup::push(one.clone(), vec![var(0), var(2)]),
+        Lookup::pull(one, vec![var(0), var(2)]),
+    ]
+}
+
+#[test]
+fn baby_bear_poseidon2_smoke_test() {
+    let commitment_parameters = CommitmentParameters {
+        log_blowup: 1,
+        cap_height: 0,
+    };
+    let fri_parameters = FriParameters {
+        log_final_poly_len: 0,
+        max_log_arity: 1,
+        num_queries: 64,
+        commit_proof_of_work_bits: 0,
+        query_proof_of_work_bits: 0,
+    };
+    let config = BabyBearPoseidon2Config::new(commitment_parameters, fri_parameters);
+    let (system, key) = System::new(config, [LookupAir::new(MulAir, lookups())]);
+    let f = Val::from_u32;
+    let trace = RowMajorMatrix::new(
+        vec![
+            f(2),
+            f(3),
+            f(6),
+            f(4),
+            f(5),
+            f(20),
+            f(7),
+            f(8),
+            f(56),
+            f(0),
+            f(0),
+            f(0),
+        ],
+        3,
+    );
+    let witness = SystemWitness::from_stage_1(vec![trace], &system);
+    let no_claims: &[&[Val]] = &[];
+    let proof = system.prove_multiple_claims(&key, no_claims, witness);
+    system
+        .verify_multiple_claims(no_claims, &proof)
+        .expect("BabyBear/Poseidon2 proof failed to verify");
+
+    // Tampered proofs must still be rejected under this config.
+    let mut tampered = proof;
+    tampered.intermediate_accumulators[0] += Challenge::ONE;
+    assert!(system.verify_multiple_claims(no_claims, &tampered).is_err());
+}

--- a/src/test_circuits/baby_bear_config.rs
+++ b/src/test_circuits/baby_bear_config.rs
@@ -45,6 +45,7 @@ struct BabyBearPoseidon2Config {
     /// on [`StarkGenericConfig::initialise_challenger`]).
     challenger_seed: Vec<Val>,
     max_log_degree: usize,
+    max_quotient_degree: usize,
 }
 
 impl BabyBearPoseidon2Config {
@@ -82,11 +83,13 @@ impl BabyBearPoseidon2Config {
             .map(Val::from_usize),
         );
         let max_log_degree = Val::TWO_ADICITY - commitment_parameters.log_blowup;
+        let max_quotient_degree = 1 << commitment_parameters.log_blowup;
         Self {
             pcs,
             perm,
             challenger_seed,
             max_log_degree,
+            max_quotient_degree,
         }
     }
 }
@@ -110,6 +113,10 @@ impl StarkGenericConfig for BabyBearPoseidon2Config {
 
     fn max_log_degree(&self) -> usize {
         self.max_log_degree
+    }
+
+    fn max_quotient_degree(&self) -> usize {
+        self.max_quotient_degree
     }
 }
 

--- a/src/test_circuits/blake3.rs
+++ b/src/test_circuits/blake3.rs
@@ -4,7 +4,7 @@ mod tests {
     use crate::lookup::{Lookup, LookupAir};
     use crate::system::{System, SystemWitness};
     use crate::test_circuits::SymbExpr;
-    use crate::types::{CommitmentParameters, FriParameters, Val};
+    use crate::types::{CommitmentParameters, FriParameters, GoldilocksKeccakConfig, Val};
     use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
     use p3_field::{Field, PrimeCharacteristicRing, PrimeField64};
     use p3_matrix::Matrix;
@@ -2249,10 +2249,19 @@ mod tests {
         assert_eq!(actual, expected.to_vec());
 
         // circuit testing
-        let commitment_parameters = CommitmentParameters {
-            log_blowup: 1,
-            cap_height: 0,
-        };
+        let config = GoldilocksKeccakConfig::new(
+            CommitmentParameters {
+                log_blowup: 1,
+                cap_height: 0,
+            },
+            FriParameters {
+                log_final_poly_len: 0,
+                max_log_arity: 1,
+                num_queries: 64,
+                commit_proof_of_work_bits: 0,
+                query_proof_of_work_bits: 0,
+            },
+        );
         let u8_circuit = LookupAir::new(
             Blake3CompressionCircuit::U8Xor,
             Blake3CompressionCircuit::U8Xor.lookups(),
@@ -2292,7 +2301,7 @@ mod tests {
         );
 
         let (system, prover_key) = System::new(
-            commitment_parameters,
+            config,
             vec![
                 u8_circuit,
                 u32_circuit,
@@ -2324,18 +2333,9 @@ mod tests {
         let claims_slice: Vec<&[Val]> = claims.claims.iter().map(|v| v.as_slice()).collect();
         let claims_slice: &[&[Val]] = &claims_slice;
 
-        let fri_parameters = FriParameters {
-            log_final_poly_len: 0,
-            max_log_arity: 1,
-            num_queries: 64,
-            commit_proof_of_work_bits: 0,
-            query_proof_of_work_bits: 0,
-        };
-
-        let proof =
-            system.prove_multiple_claims(fri_parameters, &prover_key, claims_slice, witness);
+        let proof = system.prove_multiple_claims(&prover_key, claims_slice, witness);
         system
-            .verify_multiple_claims(fri_parameters, claims_slice, &proof)
+            .verify_multiple_claims(claims_slice, &proof)
             .expect("verification issue");
     }
 
@@ -2437,10 +2437,19 @@ mod tests {
 
         fn run_test(claims: &Blake3CompressionClaims) {
             // circuit testing
-            let commitment_parameters = CommitmentParameters {
-                log_blowup: 1,
-                cap_height: 0,
-            };
+            let config = GoldilocksKeccakConfig::new(
+                CommitmentParameters {
+                    log_blowup: 1,
+                    cap_height: 0,
+                },
+                FriParameters {
+                    log_final_poly_len: 0,
+                    max_log_arity: 1,
+                    num_queries: 64,
+                    commit_proof_of_work_bits: 0,
+                    query_proof_of_work_bits: 0,
+                },
+            );
             let u8_circuit = LookupAir::new(
                 Blake3CompressionCircuit::U8Xor,
                 Blake3CompressionCircuit::U8Xor.lookups(),
@@ -2480,7 +2489,7 @@ mod tests {
             );
 
             let (system, prover_key) = System::new(
-                commitment_parameters,
+                config,
                 vec![
                     u8_circuit,
                     u32_circuit,
@@ -2499,18 +2508,9 @@ mod tests {
             let claims_slice: Vec<&[Val]> = claims.claims.iter().map(|v| v.as_slice()).collect();
             let claims_slice: &[&[Val]] = &claims_slice;
 
-            let fri_parameters = FriParameters {
-                log_final_poly_len: 0,
-                max_log_arity: 1,
-                num_queries: 64,
-                commit_proof_of_work_bits: 0,
-                query_proof_of_work_bits: 0,
-            };
-
-            let proof =
-                system.prove_multiple_claims(fri_parameters, &prover_key, claims_slice, witness);
+            let proof = system.prove_multiple_claims(&prover_key, claims_slice, witness);
             system
-                .verify_multiple_claims(fri_parameters, claims_slice, &proof)
+                .verify_multiple_claims(claims_slice, &proof)
                 .expect("verification issue");
         }
 

--- a/src/test_circuits/blake3.rs
+++ b/src/test_circuits/blake3.rs
@@ -1515,8 +1515,8 @@ mod tests {
     impl Blake3CompressionClaims {
         fn witness(
             &self,
-            system: &System<Blake3CompressionCircuit>,
-        ) -> (Vec<RowMajorMatrix<Val>>, SystemWitness) {
+            system: &System<GoldilocksKeccakConfig, Blake3CompressionCircuit>,
+        ) -> (Vec<RowMajorMatrix<Val>>, SystemWitness<Val>) {
             // Grabbing values from a claims
 
             let mut u32_xor_values_from_claims = vec![];

--- a/src/test_circuits/byte_operations.rs
+++ b/src/test_circuits/byte_operations.rs
@@ -4,7 +4,7 @@ mod tests {
     use crate::lookup::{Lookup, LookupAir};
     use crate::system::{System, SystemWitness};
     use crate::test_circuits::SymbExpr;
-    use crate::types::{CommitmentParameters, FriParameters, Val};
+    use crate::types::{CommitmentParameters, FriParameters, GoldilocksKeccakConfig, Val};
     use p3_air::{Air, AirBuilder, BaseAir};
     use p3_field::{Field, PrimeCharacteristicRing};
     use p3_matrix::dense::RowMajorMatrix;
@@ -123,12 +123,21 @@ mod tests {
 
     #[test]
     fn byte_test() {
-        let commitment_parameters = CommitmentParameters {
-            log_blowup: 1,
-            cap_height: 0,
-        };
+        let config = GoldilocksKeccakConfig::new(
+            CommitmentParameters {
+                log_blowup: 1,
+                cap_height: 0,
+            },
+            FriParameters {
+                log_final_poly_len: 0,
+                max_log_arity: 1,
+                num_queries: 64,
+                commit_proof_of_work_bits: 0,
+                query_proof_of_work_bits: 0,
+            },
+        );
         let circuit = LookupAir::new(ByteCS {}, ByteCS {}.lookups());
-        let (system, key) = System::new(commitment_parameters, vec![circuit]);
+        let (system, key) = System::new(config, vec![circuit]);
         let calls = ByteCalls {
             calls: vec![
                 (ByteOperation::Xor, 10, 5),
@@ -144,16 +153,7 @@ mod tests {
         let claim3 = &[f(2), f(100), f(40), f(100 | 40)];
         let claim4 = &[f(3), f(200), f(100)];
         let claims: &[&[Val]] = &[claim1, claim2, claim3, claim4];
-        let fri_parameters = FriParameters {
-            log_final_poly_len: 0,
-            max_log_arity: 1,
-            num_queries: 64,
-            commit_proof_of_work_bits: 0,
-            query_proof_of_work_bits: 0,
-        };
-        let proof = system.prove_multiple_claims(fri_parameters, &key, claims, witness);
-        system
-            .verify_multiple_claims(fri_parameters, claims, &proof)
-            .unwrap();
+        let proof = system.prove_multiple_claims(&key, claims, witness);
+        system.verify_multiple_claims(claims, &proof).unwrap();
     }
 }

--- a/src/test_circuits/byte_operations.rs
+++ b/src/test_circuits/byte_operations.rs
@@ -107,7 +107,7 @@ mod tests {
     }
 
     impl ByteCalls {
-        fn witness(&self, system: &System<ByteCS>) -> SystemWitness {
+        fn witness(&self, system: &System<GoldilocksKeccakConfig, ByteCS>) -> SystemWitness<Val> {
             let mut byte_trace =
                 RowMajorMatrix::new(vec![Val::ZERO; TRACE_WIDTH * 256 * 256], TRACE_WIDTH);
             for (op, x, y) in self.calls.iter() {

--- a/src/test_circuits/mod.rs
+++ b/src/test_circuits/mod.rs
@@ -1,3 +1,4 @@
+mod baby_bear_config;
 mod blake3;
 mod byte_operations;
 mod u32_add;

--- a/src/test_circuits/u32_add.rs
+++ b/src/test_circuits/u32_add.rs
@@ -9,7 +9,7 @@ mod tests {
         builder::symbolic::{preprocessed_var, var},
         lookup::{Lookup, LookupAir},
         system::{ProverKey, System, SystemWitness},
-        types::{CommitmentParameters, FriParameters, Val},
+        types::{CommitmentParameters, FriParameters, GoldilocksKeccakConfig, Val},
     };
 
     enum U32CS {
@@ -125,10 +125,10 @@ mod tests {
         }
     }
 
-    fn byte_system(commitment_parameters: CommitmentParameters) -> (System<U32CS>, ProverKey) {
+    fn byte_system(config: GoldilocksKeccakConfig) -> (System<U32CS>, ProverKey) {
         let byte_table = LookupAir::new(U32CS::ByteTable, U32CS::ByteTable.lookups());
         let u32_add = LookupAir::new(U32CS::U32Add, U32CS::U32Add.lookups());
-        System::new(commitment_parameters, [byte_table, u32_add])
+        System::new(config, [byte_table, u32_add])
     }
 
     struct AddCalls {
@@ -187,11 +187,20 @@ mod tests {
 
     #[test]
     fn u32_add_proof() {
-        let commitment_parameters = CommitmentParameters {
-            log_blowup: 1,
-            cap_height: 0,
-        };
-        let (system, key) = byte_system(commitment_parameters);
+        let config = GoldilocksKeccakConfig::new(
+            CommitmentParameters {
+                log_blowup: 1,
+                cap_height: 0,
+            },
+            FriParameters {
+                log_final_poly_len: 0,
+                max_log_arity: 1,
+                num_queries: 64,
+                commit_proof_of_work_bits: 0,
+                query_proof_of_work_bits: 0,
+            },
+        );
+        let (system, key) = byte_system(config);
         let calls = AddCalls {
             calls: vec![(10, 5), (30, 20), (100, 100), (8000, 10000)],
         };
@@ -202,16 +211,7 @@ mod tests {
         let claim3 = &[f(1), f(100), f(100), f(200)];
         let claim4 = &[f(1), f(8000), f(10000), f(18000)];
         let claims: &[&[Val]] = &[claim1, claim2, claim3, claim4];
-        let fri_parameters = FriParameters {
-            log_final_poly_len: 0,
-            max_log_arity: 1,
-            num_queries: 64,
-            commit_proof_of_work_bits: 0,
-            query_proof_of_work_bits: 0,
-        };
-        let proof = system.prove_multiple_claims(fri_parameters, &key, claims, witness);
-        system
-            .verify_multiple_claims(fri_parameters, claims, &proof)
-            .unwrap();
+        let proof = system.prove_multiple_claims(&key, claims, witness);
+        system.verify_multiple_claims(claims, &proof).unwrap();
     }
 }

--- a/src/test_circuits/u32_add.rs
+++ b/src/test_circuits/u32_add.rs
@@ -125,7 +125,12 @@ mod tests {
         }
     }
 
-    fn byte_system(config: GoldilocksKeccakConfig) -> (System<U32CS>, ProverKey) {
+    fn byte_system(
+        config: GoldilocksKeccakConfig,
+    ) -> (
+        System<GoldilocksKeccakConfig, U32CS>,
+        ProverKey<GoldilocksKeccakConfig>,
+    ) {
         let byte_table = LookupAir::new(U32CS::ByteTable, U32CS::ByteTable.lookups());
         let u32_add = LookupAir::new(U32CS::U32Add, U32CS::U32Add.lookups());
         System::new(config, [byte_table, u32_add])
@@ -136,7 +141,7 @@ mod tests {
     }
 
     impl AddCalls {
-        fn witness(&self, system: &System<U32CS>) -> SystemWitness {
+        fn witness(&self, system: &System<GoldilocksKeccakConfig, U32CS>) -> SystemWitness<Val> {
             let byte_width = 1;
             let add_width = 14;
             let mut byte_trace = RowMajorMatrix::new(vec![Val::ZERO; byte_width * 256], byte_width);

--- a/src/types.rs
+++ b/src/types.rs
@@ -52,7 +52,10 @@ impl StarkConfig {
 
     pub fn new(commitment_parameters: CommitmentParameters, fri_parameters: FriParameters) -> Self {
         let pcs = new_pcs(commitment_parameters, fri_parameters);
-        let challenger = Challenger::from_hasher(vec![], Keccak256Hash {});
+        // Seed the challenger with a protocol tag for domain separation, so
+        // transcripts cannot collide with those of other protocols built on
+        // the same hash.
+        let challenger = Challenger::from_hasher(b"multi-stark/v0".to_vec(), Keccak256Hash {});
         Self { pcs, challenger }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -48,6 +48,9 @@ pub struct GoldilocksKeccakConfig {
     challenger_seed: Vec<u8>,
     /// Largest log2 degree the PCS can commit to and open.
     max_log_degree: usize,
+    /// Largest quotient degree the PCS can serve trace evaluations for
+    /// (the FRI blowup factor).
+    max_quotient_degree: usize,
 }
 
 impl GoldilocksKeccakConfig {
@@ -72,10 +75,12 @@ impl GoldilocksKeccakConfig {
             challenger_seed.extend_from_slice(&parameter.to_le_bytes());
         }
         let max_log_degree = Val::TWO_ADICITY - commitment_parameters.log_blowup;
+        let max_quotient_degree = 1 << commitment_parameters.log_blowup;
         Self {
             pcs,
             challenger_seed,
             max_log_degree,
+            max_quotient_degree,
         }
     }
 }
@@ -95,6 +100,10 @@ impl StarkGenericConfig for GoldilocksKeccakConfig {
 
     fn max_log_degree(&self) -> usize {
         self.max_log_degree
+    }
+
+    fn max_quotient_degree(&self) -> usize {
+        self.max_quotient_degree
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,11 +1,18 @@
+//! The reference STARK configuration: Goldilocks field with a degree-2
+//! binomial extension, Keccak-256 hashing, and a FRI-based PCS.
+//!
+//! The generic protocol lives in [`crate::config`], [`crate::system`],
+//! [`crate::prover`] and [`crate::verifier`]; this module only provides a
+//! concrete, batteries-included instantiation.
+
+use crate::config::StarkGenericConfig;
 use p3_challenger::{HashChallenger, SerializingChallenger64};
 use p3_commit::{ExtensionMmcs, Pcs as PcsTrait};
 use p3_dft::Radix2DitParallel;
-use p3_field::{ExtensionField, Field, extension::BinomialExtensionField};
+use p3_field::{ExtensionField, Field, TwoAdicField, extension::BinomialExtensionField};
 use p3_fri::{FriParameters as InnerFriParameters, TwoAdicFriPcs};
 use p3_goldilocks::Goldilocks;
 use p3_keccak::{Keccak256Hash, KeccakF};
-use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher};
 
@@ -25,16 +32,6 @@ pub type Mmcs = MerkleTreeMmcs<
 pub type ExtMmcs = ExtensionMmcs<Val, ExtVal, Mmcs>;
 pub type Pcs = TwoAdicFriPcs<Val, Dft, Mmcs, ExtMmcs>;
 
-/// Configuration for the STARK prover and verifier, bundling the PCS and an
-/// initial challenger state.
-#[derive(Debug)]
-pub struct StarkConfig {
-    /// The PCS used to commit polynomials and prove opening proofs.
-    pcs: Pcs,
-    /// An initialised instance of the challenger.
-    challenger: Challenger,
-}
-
 pub type Commitment = <Pcs as PcsTrait<ExtVal, Challenger>>::Commitment;
 pub type Domain = <Pcs as PcsTrait<ExtVal, Challenger>>::Domain;
 pub type ProverData = <Pcs as PcsTrait<ExtVal, Challenger>>::ProverData;
@@ -42,55 +39,67 @@ pub type EvaluationsOnDomain<'a> = <Pcs as PcsTrait<ExtVal, Challenger>>::Evalua
 pub type PcsError = <Pcs as PcsTrait<ExtVal, Challenger>>::Error;
 pub type PcsProof = <Pcs as PcsTrait<ExtVal, Challenger>>::Proof;
 
-impl StarkConfig {
-    pub fn pcs(&self) -> &Pcs {
-        &self.pcs
-    }
-    pub fn initialise_challenger(&self) -> Challenger {
-        self.challenger.clone()
-    }
+/// The reference [`StarkGenericConfig`] implementation.
+pub struct GoldilocksKeccakConfig {
+    /// The PCS used to commit polynomials and prove opening proofs.
+    pcs: Pcs,
+    /// Seed for fresh challengers: a domain-separation tag followed by a
+    /// digest of all protocol parameters.
+    challenger_seed: Vec<u8>,
+    /// Largest log2 degree the PCS can commit to and open.
+    max_log_degree: usize,
+}
 
+impl GoldilocksKeccakConfig {
     pub fn new(commitment_parameters: CommitmentParameters, fri_parameters: FriParameters) -> Self {
         let pcs = new_pcs(commitment_parameters, fri_parameters);
-        // Seed the challenger with a protocol tag for domain separation, so
-        // transcripts cannot collide with those of other protocols built on
-        // the same hash.
-        let challenger = Challenger::from_hasher(b"multi-stark/v0".to_vec(), Keccak256Hash {});
-        Self { pcs, challenger }
+        // Seed the challenger with a protocol tag for domain separation,
+        // followed by every protocol parameter. Binding the parameters into
+        // the seed means transcripts produced under different parameters
+        // never collide (see the transcript contract on
+        // [`StarkGenericConfig::initialise_challenger`]).
+        let mut challenger_seed = b"multi-stark/v0".to_vec();
+        for parameter in [
+            commitment_parameters.log_blowup,
+            commitment_parameters.cap_height,
+            fri_parameters.log_final_poly_len,
+            fri_parameters.max_log_arity,
+            fri_parameters.num_queries,
+            fri_parameters.commit_proof_of_work_bits,
+            fri_parameters.query_proof_of_work_bits,
+        ] {
+            let parameter = u64::try_from(parameter).expect("parameter exceeds u64");
+            challenger_seed.extend_from_slice(&parameter.to_le_bytes());
+        }
+        let max_log_degree = Val::TWO_ADICITY - commitment_parameters.log_blowup;
+        Self {
+            pcs,
+            challenger_seed,
+            max_log_degree,
+        }
     }
 }
 
-/// The committer is able to commit to polynomials but not open them.
-/// This is used for preprocessed traces.
-pub struct Committer {
-    pcs: Pcs,
-}
+impl StarkGenericConfig for GoldilocksKeccakConfig {
+    type Pcs = Pcs;
+    type Challenge = ExtVal;
+    type Challenger = Challenger;
 
-impl Committer {
-    pub fn new(commitment_parameters: CommitmentParameters) -> Self {
-        let dummy_parameters = FriParameters {
-            log_final_poly_len: 0,
-            max_log_arity: 1,
-            num_queries: 0,
-            commit_proof_of_work_bits: 0,
-            query_proof_of_work_bits: 0,
-        };
-        let pcs = new_pcs(commitment_parameters, dummy_parameters);
-        Self { pcs }
+    fn pcs(&self) -> &Pcs {
+        &self.pcs
     }
 
-    pub fn natural_domain_for_degree(&self, degree: usize) -> Domain {
-        <Pcs as PcsTrait<ExtVal, Challenger>>::natural_domain_for_degree(&self.pcs, degree)
+    fn initialise_challenger(&self) -> Challenger {
+        Challenger::from_hasher(self.challenger_seed.clone(), Keccak256Hash {})
     }
 
-    pub fn commit(
-        &self,
-        evaluations: impl IntoIterator<Item = (Domain, RowMajorMatrix<Val>)>,
-    ) -> (Commitment, ProverData) {
-        <Pcs as PcsTrait<ExtVal, Challenger>>::commit(&self.pcs, evaluations)
+    fn max_log_degree(&self) -> usize {
+        self.max_log_degree
     }
 }
 
+/// Parameters of the polynomial commitment: Reed-Solomon rate and Merkle
+/// tree shape.
 #[derive(Clone, Copy)]
 pub struct CommitmentParameters {
     pub log_blowup: usize,
@@ -102,10 +111,9 @@ pub struct CommitmentParameters {
 /// Parameters controlling the FRI protocol.
 ///
 /// These parameters determine the concrete security level. The FRI soundness
-/// error is approximately `ρ^num_queries` where `ρ = 2^(-log_blowup)` (set in
-/// [`CommitmentParameters`]). For example, `log_blowup = 1` with
-/// `num_queries = 100` gives ~2^(-100) soundness error from FRI queries alone.
-/// The PoW bits add grinding cost on top of this bound.
+/// error is approximately `ρ^num_queries` (conjectured; `√ρ^num_queries`
+/// proven) where `ρ = 2^(-log_blowup)` (set in [`CommitmentParameters`]).
+/// See the verifier module docs for the full soundness argument.
 #[derive(Clone, Copy)]
 pub struct FriParameters {
     /// Log2 of the degree of the final polynomial (0 means a constant).

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -123,17 +123,16 @@
 
 use crate::{
     builder::folder::VerifierConstraintFolder,
-    config::StarkGenericConfig,
+    config::{PcsError, StarkGenericConfig, Val},
     ensure, ensure_eq,
     lookup::fingerprint,
     prover::Proof,
     system::System,
-    types::{Challenger, ExtVal, Pcs, PcsError, Val},
 };
 use p3_air::{Air, BaseAir, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
-use p3_commit::{Pcs as PcsTrait, PolynomialSpace};
-use p3_field::{BasedVectorSpace, Field, PrimeCharacteristicRing};
+use p3_commit::{Pcs, PolynomialSpace};
+use p3_field::{BasedVectorSpace, ExtensionField, Field, PrimeCharacteristicRing};
 use p3_matrix::{dense::RowMajorMatrixView, stack::VerticalPair};
 use p3_util::log2_strict_usize;
 
@@ -157,21 +156,29 @@ pub enum VerificationError<PcsErr> {
     UnbalancedChannel,
 }
 
-impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> System<A> {
+impl<SC, A> System<SC, A>
+where
+    SC: StarkGenericConfig,
+    A: BaseAir<Val<SC>> + for<'a> Air<VerifierConstraintFolder<'a, Val<SC>, SC::Challenge>>,
+{
     /// Verifies a STARK proof against a single claim.
     ///
     /// Returns `Ok(())` if the proof is valid, or a [`VerificationError`] describing
     /// the first check that failed.
-    pub fn verify(&self, claim: &[Val], proof: &Proof) -> Result<(), VerificationError<PcsError>> {
+    pub fn verify(
+        &self,
+        claim: &[Val<SC>],
+        proof: &Proof<SC>,
+    ) -> Result<(), VerificationError<PcsError<SC>>> {
         self.verify_multiple_claims(&[claim], proof)
     }
 
     /// Verifies a STARK proof against multiple claims.
     pub fn verify_multiple_claims(
         &self,
-        claims: &[&[Val]],
-        proof: &Proof,
-    ) -> Result<(), VerificationError<PcsError>> {
+        claims: &[&[Val<SC>]],
+        proof: &Proof<SC>,
+    ) -> Result<(), VerificationError<PcsError<SC>>> {
         let Proof {
             commitments,
             intermediate_accumulators,
@@ -192,7 +199,7 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
         // ≤ N / |F_ext| (Schwartz-Zippel on the numerator polynomial).
         ensure_eq!(
             intermediate_accumulators.last(),
-            Some(&ExtVal::ZERO),
+            Some(&SC::Challenge::ZERO),
             VerificationError::UnbalancedChannel
         );
 
@@ -210,13 +217,13 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
 
         // observe preprocessed and stage_1 commitment
         if let Some(commit) = &self.preprocessed_commit {
-            challenger.observe(commit);
+            challenger.observe(commit.clone());
         }
         challenger.observe(commitments.stage_1_trace.clone());
 
         // Observe trace heights to bind the proof to specific domain sizes.
         for log_degree in log_degrees {
-            challenger.observe(Val::from_u8(*log_degree));
+            challenger.observe(Val::<SC>::from_u8(*log_degree));
         }
 
         // Soundness: claims must be observed BEFORE lookup challenges are sampled.
@@ -224,9 +231,9 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
         // challenges, breaking the lookup argument's binding property. The claims
         // are length-prefixed so that distinct claim structures (e.g. [[a, b]]
         // vs [[a], [b]]) yield distinct transcripts.
-        challenger.observe(Val::from_usize(claims.len()));
+        challenger.observe(Val::<SC>::from_usize(claims.len()));
         for claim in claims {
-            challenger.observe(Val::from_usize(claim.len()));
+            challenger.observe(Val::<SC>::from_usize(claim.len()));
             challenger.observe_slice(claim);
         }
 
@@ -234,9 +241,9 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
         // The message m_i = lookup_challenge + fingerprint(fingerprint_challenge, args_i)
         // is an affine function of the challenges, ensuring that distinct argument
         // tuples produce distinct messages with probability ≥ 1 - 1/|F_ext|.
-        let lookup_argument_challenge: ExtVal = challenger.sample_algebra_element();
+        let lookup_argument_challenge: SC::Challenge = challenger.sample_algebra_element();
         challenger.observe_algebra_element(lookup_argument_challenge);
-        let fingerprint_challenge: ExtVal = challenger.sample_algebra_element();
+        let fingerprint_challenge: SC::Challenge = challenger.sample_algebra_element();
         challenger.observe_algebra_element(fingerprint_challenge);
 
         // observe stage_2 commitment
@@ -250,7 +257,7 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
         }
 
         // construct the accumulator from the claims
-        let mut acc = ExtVal::ZERO;
+        let mut acc = SC::Challenge::ZERO;
         for claim in claims {
             let message = lookup_argument_challenge
                 + fingerprint(&fingerprint_challenge, claim.iter().cloned());
@@ -260,14 +267,14 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
         // Soundness: constraint folding. All k constraints are combined via powers
         // of α. The folded sum has degree k-1 in α, so by Schwartz-Zippel a violated
         // constraint survives folding with probability ≥ 1 - (k-1)/|F_ext|.
-        let constraint_challenge: ExtVal = challenger.sample_algebra_element();
+        let constraint_challenge: SC::Challenge = challenger.sample_algebra_element();
 
         // observe quotient commitment
         challenger.observe(commitments.quotient_chunks.clone());
 
         // Soundness: OOD evaluation. ζ is sampled after all commitments are fixed.
         // A nonzero polynomial of degree ≤ D vanishes at ζ with probability ≤ D/|F_ext|.
-        let zeta: ExtVal = challenger.sample_algebra_element();
+        let zeta: SC::Challenge = challenger.sample_algebra_element();
         let mut preprocessed_trace_evaluations = vec![];
         let mut stage_1_trace_evaluations = vec![];
         let mut stage_2_trace_evaluations = vec![];
@@ -277,21 +284,13 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
             let log_degree = log_degrees[i];
             let quotient_degree = quotient_degrees[i];
             let log_quotient_degree = log2_strict_usize(quotient_degree);
-            let trace_domain = <Pcs as PcsTrait<ExtVal, Challenger>>::natural_domain_for_degree(
-                pcs,
-                1 << log_degree,
-            );
+            let trace_domain = pcs.natural_domain_for_degree(1 << log_degree);
             let quotient_domain =
                 trace_domain.create_disjoint_domain((1 << log_degree) << log_quotient_degree);
             let quotient_chunks_domains = quotient_domain.split_domains(quotient_degree);
             let unshifted_quotient_chunks_domains = quotient_chunks_domains
                 .iter()
-                .map(|domain| {
-                    <Pcs as PcsTrait<ExtVal, Challenger>>::natural_domain_for_degree(
-                        pcs,
-                        domain.size(),
-                    )
-                })
+                .map(|domain| pcs.natural_domain_for_degree(domain.size()))
                 .collect::<Vec<_>>();
             let zeta_next = trace_domain
                 .next_point(zeta)
@@ -371,8 +370,7 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
             last_quotient_i += quotient_degree;
 
             // compute the composition polynomial evaluation
-            let trace_domain =
-                <Pcs as PcsTrait<ExtVal, Challenger>>::natural_domain_for_degree(pcs, degree);
+            let trace_domain = pcs.natural_domain_for_degree(degree);
             let sels = trace_domain.selectors_at_point(zeta);
             let preprocessed = if let Some(i) = self.preprocessed_indices[i] {
                 let preprocessed_opened_values = preprocessed_opened_values.as_ref().unwrap();
@@ -386,14 +384,14 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
                 RowMajorMatrixView::new_row(stage_1_row),
                 RowMajorMatrixView::new_row(stage_1_next_row),
             );
-            let extension_d = <ExtVal as BasedVectorSpace<Val>>::DIMENSION;
+            let extension_d = <SC::Challenge as BasedVectorSpace<Val<SC>>>::DIMENSION;
             let stage_2_row = &stage_2_row
                 .chunks_exact(extension_d)
-                .map(from_ext_basis)
+                .map(from_ext_basis::<Val<SC>, SC::Challenge>)
                 .collect::<Vec<_>>();
             let stage_2_next_row = &stage_2_next_row
                 .chunks_exact(extension_d)
-                .map(from_ext_basis)
+                .map(from_ext_basis::<Val<SC>, SC::Challenge>)
                 .collect::<Vec<_>>();
             let stage_2 = VerticalPair::new(
                 RowMajorMatrixView::new_row(stage_2_row),
@@ -416,7 +414,7 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
                 is_last_row: sels.is_last_row,
                 is_transition: sels.is_transition,
                 alpha: constraint_challenge,
-                accumulator: ExtVal::ZERO,
+                accumulator: SC::Challenge::ZERO,
             };
             circuit.air.eval(&mut folder);
             let composition_polynomial = folder.accumulator;
@@ -437,13 +435,13 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
                                     .vanishing_poly_at_point(domain.first_point())
                                     .inverse()
                         })
-                        .product::<ExtVal>()
+                        .product::<SC::Challenge>()
                 })
                 .collect::<Vec<_>>();
             let quotient = quotient_chunks
                 .enumerate()
-                .map(|(ch_i, ch)| zps[ch_i] * from_ext_basis(ch))
-                .sum::<ExtVal>();
+                .map(|(ch_i, ch)| zps[ch_i] * from_ext_basis::<Val<SC>, SC::Challenge>(ch))
+                .sum::<SC::Challenge>();
 
             // Soundness: OOD check. If any constraint is violated on the trace
             // domain, the composition polynomial is not divisible by the vanishing
@@ -466,7 +464,10 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
 
     /// Validates the structural shape of the proof without checking any cryptographic
     /// properties. Returns the quotient degrees per circuit on success.
-    pub fn verify_shape(&self, proof: &Proof) -> Result<Vec<usize>, VerificationError<PcsError>> {
+    pub fn verify_shape(
+        &self,
+        proof: &Proof<SC>,
+    ) -> Result<Vec<usize>, VerificationError<PcsError<SC>>> {
         let Proof {
             intermediate_accumulators,
             log_degrees,
@@ -544,7 +545,7 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
                     circuit.stage_1_width,
                     VerificationError::InvalidProofShape
                 );
-                let extension_d = <ExtVal as BasedVectorSpace<Val>>::DIMENSION;
+                let extension_d = <SC::Challenge as BasedVectorSpace<Val<SC>>>::DIMENSION;
                 ensure_eq!(
                     stage_2_opened_values[i][j].len(),
                     circuit.stage_2_width * extension_d,
@@ -584,7 +585,7 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
             );
             ensure_eq!(
                 quotient_opened_values[i][0].len(),
-                <ExtVal as BasedVectorSpace<Val>>::DIMENSION,
+                <SC::Challenge as BasedVectorSpace<Val<SC>>>::DIMENSION,
                 VerificationError::InvalidProofShape
             );
         }
@@ -598,11 +599,11 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
     }
 }
 
-fn from_ext_basis(coeffs: &[ExtVal]) -> ExtVal {
+fn from_ext_basis<F: Field, EF: ExtensionField<F>>(coeffs: &[EF]) -> EF {
     coeffs
         .iter()
         .enumerate()
-        .map(|(i, c)| *c * <ExtVal as BasedVectorSpace<Val>>::ith_basis_element(i).unwrap())
+        .map(|(i, c)| *c * <EF as BasedVectorSpace<F>>::ith_basis_element(i).unwrap())
         .sum()
 }
 
@@ -613,7 +614,7 @@ mod tests {
         lookup::LookupAir,
         prover::Proof,
         system::{ProverKey, SystemWitness},
-        types::{CommitmentParameters, FriParameters, GoldilocksKeccakConfig},
+        types::{CommitmentParameters, ExtVal, FriParameters, GoldilocksKeccakConfig, Val},
     };
     use p3_air::{AirBuilder, BaseAir, WindowAccess};
     use p3_matrix::dense::RowMajorMatrix;
@@ -672,7 +673,10 @@ mod tests {
         query_proof_of_work_bits: 0,
     };
 
-    fn system() -> (System<CS>, ProverKey) {
+    fn system() -> (
+        System<GoldilocksKeccakConfig, CS>,
+        ProverKey<GoldilocksKeccakConfig>,
+    ) {
         let config = GoldilocksKeccakConfig::new(COMMITMENT_PARAMETERS, FRI_PARAMETERS);
         let pythagorean_circuit = LookupAir::new(CS::Pythagorean, vec![]);
         let complex_circuit = LookupAir::new(CS::Complex, vec![]);
@@ -727,7 +731,10 @@ mod tests {
     // -- Negative / adversarial tests --
 
     /// Helper: creates a small system and valid proof for negative tests.
-    fn small_system_and_proof() -> (System<CS>, Proof) {
+    fn small_system_and_proof() -> (
+        System<GoldilocksKeccakConfig, CS>,
+        Proof<GoldilocksKeccakConfig>,
+    ) {
         let (system, key) = system();
         let f = Val::from_u32;
         let witness = SystemWitness::from_stage_1(

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -10,8 +10,10 @@
 //!    ensuring that all lookup pushes and pulls cancel out across circuits.
 //!
 //! 3. **Fiat-Shamir replay**: Reconstruct the challenger state identically to the
-//!    prover by observing commitments, trace heights, claims, and sampling the same
-//!    challenges (lookup, fingerprint, constraint alpha, OOD zeta).
+//!    prover: starting from the parameter-seeded challenger, observe the system
+//!    shape, commitments, trace heights, length-prefixed claims, and intermediate
+//!    accumulators, sampling the same challenges (lookup, fingerprint, constraint
+//!    alpha, OOD zeta) at the same points in the transcript.
 //!
 //! 4. **PCS verification**: Verify the FRI opening proofs against the committed
 //!    polynomials at the sampled points.
@@ -25,7 +27,7 @@
 //! # Soundness argument
 //!
 //! The protocol is sound in the random oracle model, instantiated by the
-//! configuration's Fiat-Shamir challenger (Keccak-256 in the reference config).
+//! configuration's Fiat-Shamir challenger.
 //! Informally: if a prover produces a proof that the verifier accepts, then with
 //! overwhelming probability the claimed computation is correct.
 //!
@@ -211,10 +213,11 @@ where
         );
 
         // Soundness: Fiat-Shamir. All challenges below are derived deterministically
-        // from the transcript via Keccak-256 (random oracle model). The verifier
-        // replays exactly the same observations as the prover, so any divergence
-        // (e.g. different commitments) produces different challenges, making it
-        // infeasible for a cheating prover to predict them.
+        // from the transcript via the configuration's challenger, whose hash is
+        // modeled as a random oracle. The verifier replays exactly the same
+        // observations as the prover, so any divergence (e.g. different
+        // commitments) produces different challenges, making it infeasible for a
+        // cheating prover to predict them.
         let pcs = self.config.pcs();
         let mut challenger = self.config.initialise_challenger();
 

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -156,7 +156,7 @@ pub enum VerificationError<PcsErr> {
     UnbalancedChannel,
 }
 
-impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a>>> System<A> {
+impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> System<A> {
     /// Verifies a STARK proof against a single claim.
     ///
     /// Returns `Ok(())` if the proof is valid, or a [`VerificationError`] describing

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -123,16 +123,17 @@
 
 use crate::{
     builder::folder::VerifierConstraintFolder,
+    config::StarkGenericConfig,
     ensure, ensure_eq,
     lookup::fingerprint,
     prover::Proof,
     system::System,
-    types::{Challenger, ExtVal, FriParameters, Pcs, PcsError, StarkConfig, Val},
+    types::{Challenger, ExtVal, Pcs, PcsError, Val},
 };
 use p3_air::{Air, BaseAir, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs as PcsTrait, PolynomialSpace};
-use p3_field::{BasedVectorSpace, Field, PrimeCharacteristicRing, TwoAdicField};
+use p3_field::{BasedVectorSpace, Field, PrimeCharacteristicRing};
 use p3_matrix::{dense::RowMajorMatrixView, stack::VerticalPair};
 use p3_util::log2_strict_usize;
 
@@ -161,19 +162,13 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
     ///
     /// Returns `Ok(())` if the proof is valid, or a [`VerificationError`] describing
     /// the first check that failed.
-    pub fn verify(
-        &self,
-        fri_parameters: FriParameters,
-        claim: &[Val],
-        proof: &Proof,
-    ) -> Result<(), VerificationError<PcsError>> {
-        self.verify_multiple_claims(fri_parameters, &[claim], proof)
+    pub fn verify(&self, claim: &[Val], proof: &Proof) -> Result<(), VerificationError<PcsError>> {
+        self.verify_multiple_claims(&[claim], proof)
     }
 
     /// Verifies a STARK proof against multiple claims.
     pub fn verify_multiple_claims(
         &self,
-        fri_parameters: FriParameters,
         claims: &[&[Val]],
         proof: &Proof,
     ) -> Result<(), VerificationError<PcsError>> {
@@ -206,12 +201,12 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
         // replays exactly the same observations as the prover, so any divergence
         // (e.g. different commitments) produces different challenges, making it
         // infeasible for a cheating prover to predict them.
-        let config = StarkConfig::new(self.commitment_parameters, fri_parameters);
-        let pcs = config.pcs();
-        let mut challenger = config.initialise_challenger();
+        let pcs = self.config.pcs();
+        let mut challenger = self.config.initialise_challenger();
 
-        // bind the protocol parameters and system shape into the transcript
-        self.observe_shape(&fri_parameters, &mut challenger);
+        // Bind the system shape into the transcript. The protocol parameters
+        // are already bound via the challenger seed.
+        self.observe_shape(&mut challenger);
 
         // observe preprocessed and stage_1 commitment
         if let Some(commit) = &self.preprocessed_commit {
@@ -298,7 +293,9 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
                     )
                 })
                 .collect::<Vec<_>>();
-            let zeta_next = zeta * trace_domain.subgroup_generator();
+            let zeta_next = trace_domain
+                .next_point(zeta)
+                .ok_or(VerificationError::InvalidProofShape)?;
             if let Some(i) = self.preprocessed_indices[i] {
                 let preprocessed_opened_values = preprocessed_opened_values.as_ref().unwrap();
                 preprocessed_trace_evaluations.push((
@@ -559,15 +556,13 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a, Val, ExtVal>>> S
         let mut quotient_degrees = vec![];
         for (circuit, log_degree) in self.circuits.iter().zip(log_degrees) {
             let quotient_degree = circuit.quotient_degree();
-            // The claimed log degree must be small enough that the blown-up
-            // quotient domain still fits within the two-adic subgroup of the
-            // field. This also guards the `1 << log_degree` shifts used during
-            // verification against overflow on adversarial proofs.
+            // The claimed log degree must be small enough that the quotient
+            // domain can still be committed and opened by the PCS. This also
+            // guards the `1 << log_degree` shifts used during verification
+            // against overflow on adversarial proofs.
             ensure!(
-                usize::from(*log_degree)
-                    + log2_strict_usize(quotient_degree)
-                    + self.commitment_parameters.log_blowup
-                    <= Val::TWO_ADICITY,
+                usize::from(*log_degree) + log2_strict_usize(quotient_degree)
+                    <= self.config.max_log_degree(),
                 VerificationError::InvalidProofShape
             );
             quotient_degrees.push(quotient_degree);
@@ -618,7 +613,7 @@ mod tests {
         lookup::LookupAir,
         prover::Proof,
         system::{ProverKey, SystemWitness},
-        types::{CommitmentParameters, FriParameters},
+        types::{CommitmentParameters, FriParameters, GoldilocksKeccakConfig},
     };
     use p3_air::{AirBuilder, BaseAir, WindowAccess};
     use p3_matrix::dense::RowMajorMatrix;
@@ -664,22 +659,29 @@ mod tests {
             }
         }
     }
-    fn system(commitment_parameters: CommitmentParameters) -> (System<CS>, ProverKey) {
+    const COMMITMENT_PARAMETERS: CommitmentParameters = CommitmentParameters {
+        log_blowup: 1,
+        cap_height: 0,
+    };
+
+    const FRI_PARAMETERS: FriParameters = FriParameters {
+        log_final_poly_len: 0,
+        max_log_arity: 1,
+        num_queries: 64,
+        commit_proof_of_work_bits: 0,
+        query_proof_of_work_bits: 0,
+    };
+
+    fn system() -> (System<CS>, ProverKey) {
+        let config = GoldilocksKeccakConfig::new(COMMITMENT_PARAMETERS, FRI_PARAMETERS);
         let pythagorean_circuit = LookupAir::new(CS::Pythagorean, vec![]);
         let complex_circuit = LookupAir::new(CS::Complex, vec![]);
-        System::new(
-            commitment_parameters,
-            [pythagorean_circuit, complex_circuit],
-        )
+        System::new(config, [pythagorean_circuit, complex_circuit])
     }
 
     #[test]
     fn multi_stark_test() {
-        let commitment_parameters = CommitmentParameters {
-            log_blowup: 1,
-            cap_height: 0,
-        };
-        let (system, key) = system(commitment_parameters);
+        let (system, key) = system();
         let f = Val::from_u32;
         let witness = SystemWitness::from_stage_1(
             vec![
@@ -691,27 +693,14 @@ mod tests {
             ],
             &system,
         );
-        let fri_parameters = FriParameters {
-            log_final_poly_len: 0,
-            max_log_arity: 1,
-            num_queries: 64,
-            commit_proof_of_work_bits: 0,
-            query_proof_of_work_bits: 0,
-        };
         let no_claims = &[];
-        let proof = system.prove_multiple_claims(fri_parameters, &key, no_claims, witness);
-        system
-            .verify_multiple_claims(fri_parameters, no_claims, &proof)
-            .unwrap();
+        let proof = system.prove_multiple_claims(&key, no_claims, witness);
+        system.verify_multiple_claims(no_claims, &proof).unwrap();
     }
 
     #[test]
     fn multi_stark_prove_verify_serialize() {
-        let commitment_parameters = CommitmentParameters {
-            log_blowup: 1,
-            cap_height: 0,
-        };
-        let (system, key) = system(commitment_parameters);
+        let (system, key) = system();
         let f = Val::from_u32;
         // 2^4 = 16 rows — small enough for fast CI
         let mut pythagorean_trace = [3, 4, 5].map(f).to_vec();
@@ -727,32 +716,19 @@ mod tests {
             ],
             &system,
         );
-        let fri_parameters = FriParameters {
-            log_final_poly_len: 0,
-            max_log_arity: 1,
-            num_queries: 64,
-            commit_proof_of_work_bits: 0,
-            query_proof_of_work_bits: 0,
-        };
         let no_claims = &[];
-        let proof = system.prove_multiple_claims(fri_parameters, &key, no_claims, witness);
+        let proof = system.prove_multiple_claims(&key, no_claims, witness);
         // Serialization round-trip
         let proof_bytes = proof.to_bytes().expect("Failed to serialize proof");
         let proof2 = Proof::from_bytes(&proof_bytes).expect("Failed to deserialize proof");
-        system
-            .verify_multiple_claims(fri_parameters, no_claims, &proof2)
-            .unwrap();
+        system.verify_multiple_claims(no_claims, &proof2).unwrap();
     }
 
     // -- Negative / adversarial tests --
 
     /// Helper: creates a small system and valid proof for negative tests.
-    fn small_system_and_proof() -> (System<CS>, FriParameters, Proof) {
-        let commitment_parameters = CommitmentParameters {
-            log_blowup: 1,
-            cap_height: 0,
-        };
-        let (system, key) = system(commitment_parameters);
+    fn small_system_and_proof() -> (System<CS>, Proof) {
+        let (system, key) = system();
         let f = Val::from_u32;
         let witness = SystemWitness::from_stage_1(
             vec![
@@ -764,88 +740,79 @@ mod tests {
             ],
             &system,
         );
-        let fri_parameters = FriParameters {
-            log_final_poly_len: 0,
-            max_log_arity: 1,
-            num_queries: 64,
-            commit_proof_of_work_bits: 0,
-            query_proof_of_work_bits: 0,
-        };
         let no_claims = &[];
-        let proof = system.prove_multiple_claims(fri_parameters, &key, no_claims, witness);
-        (system, fri_parameters, proof)
+        let proof = system.prove_multiple_claims(&key, no_claims, witness);
+        (system, proof)
     }
 
     #[test]
     fn test_wrong_claim_rejected() {
-        let (system, fri_parameters, proof) = small_system_and_proof();
+        let (system, proof) = small_system_and_proof();
         let f = Val::from_u32;
         // Verify with a bogus claim — the prover used no claims, so any claim should fail.
-        let result = system.verify(fri_parameters, &[f(42)], &proof);
+        let result = system.verify(&[f(42)], &proof);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_tampered_stage_1_values_rejected() {
-        let (system, fri_parameters, mut proof) = small_system_and_proof();
+        let (system, mut proof) = small_system_and_proof();
         // Mutate a value in the stage 1 opened values — FRI should catch this.
         proof.stage_1_opened_values[0][0][0] += ExtVal::ONE;
         let no_claims: &[&[Val]] = &[];
-        let result = system.verify_multiple_claims(fri_parameters, no_claims, &proof);
+        let result = system.verify_multiple_claims(no_claims, &proof);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_tampered_accumulator_rejected() {
-        let (system, fri_parameters, mut proof) = small_system_and_proof();
+        let (system, mut proof) = small_system_and_proof();
         // Set the last intermediate accumulator to non-zero.
         let last = proof.intermediate_accumulators.len() - 1;
         proof.intermediate_accumulators[last] = ExtVal::ONE;
         let no_claims: &[&[Val]] = &[];
-        let result = system.verify_multiple_claims(fri_parameters, no_claims, &proof);
+        let result = system.verify_multiple_claims(no_claims, &proof);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_truncated_log_degrees_rejected() {
-        let (system, fri_parameters, mut proof) = small_system_and_proof();
+        let (system, mut proof) = small_system_and_proof();
         // Remove a log degree — the shape check must reject this instead of
         // the verifier panicking on an out-of-bounds index.
         proof.log_degrees.pop();
         let no_claims: &[&[Val]] = &[];
-        let result = system.verify_multiple_claims(fri_parameters, no_claims, &proof);
+        let result = system.verify_multiple_claims(no_claims, &proof);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_oversized_log_degree_rejected() {
-        let (system, fri_parameters, mut proof) = small_system_and_proof();
+        let (system, mut proof) = small_system_and_proof();
         // A log degree beyond the field's two-adicity must be rejected instead
         // of causing a shift overflow or a panic inside the PCS.
         proof.log_degrees[0] = 200;
         let no_claims: &[&[Val]] = &[];
-        let result = system.verify_multiple_claims(fri_parameters, no_claims, &proof);
+        let result = system.verify_multiple_claims(no_claims, &proof);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_truncated_proof_rejected() {
-        let (system, fri_parameters, mut proof) = small_system_and_proof();
+        let (system, mut proof) = small_system_and_proof();
         // Remove a quotient opened value — shape check should fail.
         proof.quotient_opened_values.pop();
         let no_claims: &[&[Val]] = &[];
-        let result = system.verify_multiple_claims(fri_parameters, no_claims, &proof);
+        let result = system.verify_multiple_claims(no_claims, &proof);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_serialization_round_trip() {
-        let (system, fri_parameters, proof) = small_system_and_proof();
+        let (system, proof) = small_system_and_proof();
         let bytes = proof.to_bytes().expect("serialize");
         let proof2 = Proof::from_bytes(&bytes).expect("deserialize");
         let no_claims: &[&[Val]] = &[];
-        system
-            .verify_multiple_claims(fri_parameters, no_claims, &proof2)
-            .unwrap();
+        system.verify_multiple_claims(no_claims, &proof2).unwrap();
     }
 }

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -24,13 +24,18 @@
 //!
 //! # Soundness argument
 //!
-//! The protocol is sound in the random oracle model (instantiated by Keccak-256 via
-//! the Fiat-Shamir challenger). Informally: if a prover produces a proof that the
-//! verifier accepts, then with overwhelming probability the claimed computation is
-//! correct.
+//! The protocol is sound in the random oracle model, instantiated by the
+//! configuration's Fiat-Shamir challenger (Keccak-256 in the reference config).
+//! Informally: if a prover produces a proof that the verifier accepts, then with
+//! overwhelming probability the claimed computation is correct.
 //!
 //! We use the following notation throughout:
-//! - |F_ext| ≈ 2^128 — size of the extension field (GoldilocksBinomialExtension<2>)
+//! - |F_ext| — size of the challenge (extension) field. All Schwartz-Zippel
+//!   terms below scale with 1/|F_ext|, so the configuration must pick an
+//!   extension large enough for the target security level: the reference
+//!   config's degree-2 Goldilocks extension gives |F_ext| ≈ 2^128; a degree-4
+//!   BabyBear extension gives ≈ 2^124; a degree-2 BabyBear extension (≈ 2^62)
+//!   would be far too small.
 //! - ρ = 2^(-log_blowup) — FRI rate parameter (inverse of the blowup factor)
 //! - n — number of FRI queries (`num_queries`)
 //! - k — number of AIR constraints (after lookup expansion)
@@ -67,7 +72,7 @@
 //! k - 1 in α. By the Schwartz-Zippel lemma, if any individual constraint C_i is
 //! nonzero, the folded sum is nonzero with probability at least
 //! **1 - (k - 1) / |F_ext|**, which is negligible for practical constraint counts
-//! since |F_ext| ≈ 2^128.
+//! when |F_ext| is around 2^128.
 //!
 //! ## Out-of-domain evaluation (ζ)
 //!
@@ -93,8 +98,9 @@
 //!
 //! ## Fiat-Shamir (random oracle model)
 //!
-//! All challenges (α, ζ, β, γ) are derived from the transcript via Keccak-256.
-//! Security relies on Keccak-256 behaving as a random oracle. The ordering of
+//! All challenges (α, ζ, β, γ) are derived from the transcript via the
+//! configuration's challenger. Security relies on the underlying hash behaving
+//! as a random oracle. The ordering of
 //! observations is critical: in particular, claims must be observed *before* lookup
 //! challenges are sampled, otherwise the prover could choose claims adaptively to
 //! make the accumulator balance.
@@ -108,8 +114,9 @@
 //! ```
 //!
 //! where ε_FRI is the FRI soundness error (see above for the conjectured vs proven
-//! regimes). The second term is negligible for any practical parameters since
-//! |F_ext| ≈ 2^128, so **FRI dominates**. With `log_blowup = 1` and
+//! regimes). With a sufficiently large challenge field (|F_ext| ≈ 2^128) the
+//! second term is negligible for any practical parameters, so **FRI dominates**.
+//! With `log_blowup = 1` and
 //! `num_queries = 100`, the protocol provides approximately 100 bits of conjectured
 //! security (≈ 50 bits proven) from FRI alone, plus additional grinding cost from
 //! PoW.

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -40,12 +40,20 @@
 //! ## FRI proximity test
 //!
 //! The FRI-based PCS guarantees that committed polynomials are close to polynomials
-//! of the claimed degree. The exact soundness bound depends on the proximity
-//! parameter, number of folding rounds, and folding arity; a commonly cited
-//! approximation is **ρ^n** (each of the n queries independently catches a cheating
-//! prover with probability ≈ 1 - ρ). With `log_blowup = 1` and `num_queries = 100`,
-//! this gives ≈ 2^(-100). For the precise bound, see the FRI soundness analysis in
-//! the Plonky3 documentation.
+//! of the claimed degree. Two regimes must be distinguished when picking parameters:
+//!
+//! - **Conjectured soundness** (up to list-decoding capacity): each query catches a
+//!   cheating prover with probability ≈ 1 - ρ, giving a query-phase error of ≈ **ρ^n**.
+//!   With `log_blowup = 1` and `num_queries = 100`, this is ≈ 2^(-100).
+//! - **Proven soundness** (Johnson bound): each query only provably catches a
+//!   cheating prover with probability ≈ 1 - √ρ, giving ≈ **(√ρ)^n** — roughly half
+//!   the bits of the conjectured bound. The same parameters provably give only
+//!   ≈ 2^(-50).
+//!
+//! Like most production STARKs, parameters here are typically chosen against the
+//! conjectured bound; be aware of the distinction when quoting a security level.
+//! For the precise bounds, see the FRI soundness analysis in the Plonky3
+//! documentation.
 //!
 //! The proof-of-work (PoW) phases add grinding cost: a cheating prover must perform
 //! 2^(commit_proof_of_work_bits) work per batching challenge and
@@ -99,10 +107,19 @@
 //! ε ≤ ε_FRI + (k - 1 + D + N) / |F_ext|
 //! ```
 //!
-//! where ε_FRI ≈ ρ^n is the FRI soundness error. The second term is negligible
-//! for any practical parameters since |F_ext| ≈ 2^128, so **FRI dominates**. With
-//! `log_blowup = 1` and `num_queries = 100`, the protocol provides approximately
-//! 100 bits of security from FRI alone, plus additional grinding cost from PoW.
+//! where ε_FRI is the FRI soundness error (see above for the conjectured vs proven
+//! regimes). The second term is negligible for any practical parameters since
+//! |F_ext| ≈ 2^128, so **FRI dominates**. With `log_blowup = 1` and
+//! `num_queries = 100`, the protocol provides approximately 100 bits of conjectured
+//! security (≈ 50 bits proven) from FRI alone, plus additional grinding cost from
+//! PoW.
+//!
+//! ## Not zero-knowledge
+//!
+//! This protocol is a succinct argument of knowledge, **not** a zero-knowledge
+//! proof: traces are committed without blinding, and FRI query responses reveal
+//! actual low-degree-extension values of the witness. Do not use it when the
+//! witness must remain hidden from the verifier.
 
 use crate::{
     builder::folder::VerifierConstraintFolder,

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -193,6 +193,9 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a>>> System<A> {
         let pcs = config.pcs();
         let mut challenger = config.initialise_challenger();
 
+        // bind the protocol parameters and system shape into the transcript
+        self.observe_shape(&fri_parameters, &mut challenger);
+
         // observe preprocessed and stage_1 commitment
         if let Some(commit) = &self.preprocessed_commit {
             challenger.observe(commit);
@@ -206,8 +209,12 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a>>> System<A> {
 
         // Soundness: claims must be observed BEFORE lookup challenges are sampled.
         // Otherwise, the prover could choose claims adaptively after seeing the
-        // challenges, breaking the lookup argument's binding property.
+        // challenges, breaking the lookup argument's binding property. The claims
+        // are length-prefixed so that distinct claim structures (e.g. [[a, b]]
+        // vs [[a], [b]]) yield distinct transcripts.
+        challenger.observe(Val::from_usize(claims.len()));
         for claim in claims {
+            challenger.observe(Val::from_usize(claim.len()));
             challenger.observe_slice(claim);
         }
 
@@ -222,6 +229,13 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a>>> System<A> {
 
         // observe stage_2 commitment
         challenger.observe(commitments.stage_2_trace.clone());
+
+        // Observe the intermediate accumulators. They enter the constraints as
+        // public values, so later challenges (α, ζ) must depend on them
+        // directly rather than only through the quotient commitment.
+        for acc in intermediate_accumulators {
+            challenger.observe_algebra_element(*acc);
+        }
 
         // construct the accumulator from the claims
         let mut acc = ExtVal::ZERO;

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -115,7 +115,7 @@ use crate::{
 use p3_air::{Air, BaseAir, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs as PcsTrait, PolynomialSpace};
-use p3_field::{BasedVectorSpace, Field, PrimeCharacteristicRing};
+use p3_field::{BasedVectorSpace, Field, PrimeCharacteristicRing, TwoAdicField};
 use p3_matrix::{dense::RowMajorMatrixView, stack::VerticalPair};
 use p3_util::log2_strict_usize;
 
@@ -441,6 +441,7 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a>>> System<A> {
     pub fn verify_shape(&self, proof: &Proof) -> Result<Vec<usize>, VerificationError<PcsError>> {
         let Proof {
             intermediate_accumulators,
+            log_degrees,
             quotient_opened_values,
             preprocessed_opened_values,
             stage_1_opened_values,
@@ -451,6 +452,12 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a>>> System<A> {
         let num_circuits = self.circuits.len();
         // there must be at least one circuit
         ensure!(num_circuits > 0, VerificationError::InvalidSystem);
+        // there must be one log degree per circuit
+        ensure_eq!(
+            log_degrees.len(),
+            num_circuits,
+            VerificationError::InvalidProofShape
+        );
         // the preprocessed commitment is empty if and only if there are zero preprocessed circuits
         let num_preprocessed = self
             .preprocessed_indices
@@ -519,8 +526,19 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a>>> System<A> {
         }
         // quotient round
         let mut quotient_degrees = vec![];
-        for circuit in self.circuits.iter() {
+        for (circuit, log_degree) in self.circuits.iter().zip(log_degrees) {
             let quotient_degree = (circuit.max_constraint_degree.max(2) - 1).next_power_of_two();
+            // The claimed log degree must be small enough that the blown-up
+            // quotient domain still fits within the two-adic subgroup of the
+            // field. This also guards the `1 << log_degree` shifts used during
+            // verification against overflow on adversarial proofs.
+            ensure!(
+                usize::from(*log_degree)
+                    + log2_strict_usize(quotient_degree)
+                    + self.commitment_parameters.log_blowup
+                    <= Val::TWO_ADICITY,
+                VerificationError::InvalidProofShape
+            );
             quotient_degrees.push(quotient_degree);
         }
         let quotient_size: usize = quotient_degrees.iter().sum();
@@ -752,6 +770,28 @@ mod tests {
         // Set the last intermediate accumulator to non-zero.
         let last = proof.intermediate_accumulators.len() - 1;
         proof.intermediate_accumulators[last] = ExtVal::ONE;
+        let no_claims: &[&[Val]] = &[];
+        let result = system.verify_multiple_claims(fri_parameters, no_claims, &proof);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_truncated_log_degrees_rejected() {
+        let (system, fri_parameters, mut proof) = small_system_and_proof();
+        // Remove a log degree — the shape check must reject this instead of
+        // the verifier panicking on an out-of-bounds index.
+        proof.log_degrees.pop();
+        let no_claims: &[&[Val]] = &[];
+        let result = system.verify_multiple_claims(fri_parameters, no_claims, &proof);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_oversized_log_degree_rejected() {
+        let (system, fri_parameters, mut proof) = small_system_and_proof();
+        // A log degree beyond the field's two-adicity must be rejected instead
+        // of causing a shift overflow or a panic inside the PCS.
+        proof.log_degrees[0] = 200;
         let no_claims: &[&[Val]] = &[];
         let result = system.verify_multiple_claims(fri_parameters, no_claims, &proof);
         assert!(result.is_err());

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -541,7 +541,7 @@ impl<A: BaseAir<Val> + for<'a> Air<VerifierConstraintFolder<'a>>> System<A> {
         // quotient round
         let mut quotient_degrees = vec![];
         for (circuit, log_degree) in self.circuits.iter().zip(log_degrees) {
-            let quotient_degree = (circuit.max_constraint_degree.max(2) - 1).next_power_of_two();
+            let quotient_degree = circuit.quotient_degree();
             // The claimed log degree must be small enough that the blown-up
             // quotient domain still fits within the two-adic subgroup of the
             // field. This also guards the `1 << log_degree` shifts used during


### PR DESCRIPTION
# Harden the protocol and make it generic over field, hash, and PCS

This PR contains two bodies of work: security/robustness fixes from a code
review, and a refactor that makes the protocol generic over a configuration
trait instead of being hardwired to Goldilocks + Keccak-256.

## Security and robustness fixes

- **Panic-free verifier on adversarial proofs.** `verify_shape` now validates
  `log_degrees` (one entry per circuit, each small enough for the PCS).
  Previously a malformed proof could panic the verifier via an out-of-bounds
  index or a shift overflow — a DoS vector for any service verifying
  untrusted proofs.
- **Fiat-Shamir transcript hardening.** The challenger is seeded with a domain
  tag and a digest of all protocol parameters; the circuit shape (widths,
  constraint counts, degrees) is observed before any commitment; claims are
  length-prefixed so `[[a, b]]` and `[[a], [b]]` produce distinct
  transcripts; intermediate lookup accumulators are observed before sampling
  the constraint challenge.
- **Witness validation.** `SystemWitness::from_stage_1` asserts one trace per
  circuit and that main and preprocessed trace heights match, instead of
  silently truncating lookups via `zip`.
- **Honest docs.** The soundness argument now distinguishes conjectured
  (`ρ^n`, ~2^-100 at the default parameters) from proven Johnson-bound
  (~2^-50) FRI soundness, and states prominently that the protocol is **not**
  zero-knowledge (no trace blinding; FRI openings reveal witness data).

## Genericity refactor

The protocol is now parameterized by `StarkGenericConfig` (`src/config.rs`,
modeled on `p3-uni-stark`): a PCS (which determines the base field), a
challenge field, and a Fiat-Shamir challenger.

- `System<SC, A>`, `Proof<SC>`, `ProverKey<SC>`, `SystemWitness<F>`, and the
  builders/folders are generic; `GoldilocksKeccakConfig` (`src/types.rs`) is
  the batteries-included reference instantiation.
- `System::new(config, airs)` replaces the `Committer` and its dummy FRI
  parameters; `prove`/`verify` no longer take `FriParameters` — the config
  carries them, so proving and verifying under mismatched parameters is no
  longer expressible.
- The symbolic builder tags all variables and expressions with the challenge
  field, making `Expr` and `ExprEF` the same type. This sidesteps a trait
  coherence conflict that made the old `SymbolicExpression<Val>` →
  `SymbolicExpression<ExtVal>` conversion impossible to genericize.
- A second configuration (BabyBear, degree-4 extension, Poseidon2) lives in
  the test suite and differs from the reference config in both the field and
  hash axes, so changes that only compile for the reference config fail CI.

## Breaking changes

- **API**: `System::new` takes a config; `prove`/`verify` lost their
  `FriParameters` argument; most public types gained a config parameter.
- **Transcript**: proofs generated by earlier versions no longer verify.
- **Toolchain**: Rust 1.88 → 1.91. Rust 1.88 miscompiles Plonky3's packed
  BabyBear code under `-Ctarget-cpu=native` (which this repo enables),
  producing Merkle cap mismatches; Plonky3's own tests fail at the pinned
  rev under 1.88 + native SIMD and pass under 1.91. CI images pinned to
  1.88 need updating.

## Testing

- 19/19 tests pass (including Blake3 integration and the new
  BabyBear/Poseidon2 smoke test), clippy clean, all four examples run, and
  benches compile, with and without the `parallel` feature.
- New negative tests: truncated/oversized `log_degrees`, regrouped claims,
  mismatched preprocessed heights, and tampered proofs under the second
  config.
