### PR TITLE
feat: Sparse systems — per-proof circuit activation

### DIFF
--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -298,6 +298,9 @@ mod tests {
     enum CS {
         Even,
         Odd,
+        /// A circuit on its own channel that nothing references; used by the
+        /// sparse-activation tests as the deactivated table.
+        Dead,
     }
     impl<F> BaseAir<F> for CS {
         fn width(&self) -> usize {
@@ -344,6 +347,10 @@ mod tests {
                         vec![even_index, input - one, recursion_output],
                     ),
                 ],
+                Self::Dead => vec![Lookup::pull(
+                    multiplicity,
+                    vec![Val::from_u32(2).into(), input],
+                )],
             }
         }
     }
@@ -394,41 +401,42 @@ mod tests {
         System::new(config, [even, odd])
     }
 
-    fn witness(system: &System<GoldilocksBlake3Config, CS>) -> SystemWitness<Val> {
+    fn witness_traces() -> Vec<RowMajorMatrix<Val>> {
         let f = Val::from_u32;
         #[rustfmt::skip]
-        let witness = SystemWitness::from_stage_1(
-            vec![
-                RowMajorMatrix::new(
-                    vec![
-                        // row 1
-                        f(1), f(4), f(4).inverse(), f(0), f(1), f(1),
-                        // row 2
-                        f(1), f(2), f(2).inverse(), f(0), f(1), f(1),
-                        // row 3
-                        f(1), f(0), f(0), f(1), f(0), f(0),
-                        // row 4
-                        f(0), f(0), f(0), f(0), f(0), f(0),
-                    ],
-                    6,
-                ),
-                RowMajorMatrix::new(
-                    vec![
-                        // row 1
-                        f(1), f(3), f(3).inverse(), f(0), f(1), f(1),
-                        // row 2
-                        f(1), f(1), f(1).inverse(), f(0), f(1), f(1),
-                        // row 3
-                        f(0), f(0), f(0), f(0), f(0), f(0),
-                        // row 4
-                        f(0), f(0), f(0), f(0), f(0), f(0),
-                    ],
-                    6,
-                ),
-            ],
-            system,
-        );
-        witness
+        let traces = vec![
+            RowMajorMatrix::new(
+                vec![
+                    // row 1
+                    f(1), f(4), f(4).inverse(), f(0), f(1), f(1),
+                    // row 2
+                    f(1), f(2), f(2).inverse(), f(0), f(1), f(1),
+                    // row 3
+                    f(1), f(0), f(0), f(1), f(0), f(0),
+                    // row 4
+                    f(0), f(0), f(0), f(0), f(0), f(0),
+                ],
+                6,
+            ),
+            RowMajorMatrix::new(
+                vec![
+                    // row 1
+                    f(1), f(3), f(3).inverse(), f(0), f(1), f(1),
+                    // row 2
+                    f(1), f(1), f(1).inverse(), f(0), f(1), f(1),
+                    // row 3
+                    f(0), f(0), f(0), f(0), f(0), f(0),
+                    // row 4
+                    f(0), f(0), f(0), f(0), f(0), f(0),
+                ],
+                6,
+            ),
+        ];
+        traces
+    }
+
+    fn witness(system: &System<GoldilocksBlake3Config, CS>) -> SystemWitness<Val> {
+        SystemWitness::from_stage_1(witness_traces(), system)
     }
 
     #[test]
@@ -439,6 +447,70 @@ mod tests {
         let claim = &[f(0), f(4), f(1)];
         let proof = system.prove(&key, claim, witness);
         system.verify(claim, &proof).unwrap();
+    }
+
+    /// A three-circuit system where the third circuit (`Dead`, its own
+    /// channel, referenced by nothing) gets an empty trace: the prover must
+    /// deactivate it, the proof must carry per-circuit data for the two
+    /// active circuits only, and verification must accept.
+    #[test]
+    fn sparse_inactive_circuit_accepted() {
+        let config = GoldilocksBlake3Config::new(COMMITMENT_PARAMETERS, FRI_PARAMETERS);
+        let even = LookupAir::new(CS::Even, CS::Even.lookups());
+        let odd = LookupAir::new(CS::Odd, CS::Odd.lookups());
+        let dead = LookupAir::new(CS::Dead, CS::Dead.lookups());
+        let (system, key) = System::new(config, [even, odd, dead]);
+        let mut witness = witness_traces();
+        witness.push(RowMajorMatrix::new(vec![], 6));
+        let witness = SystemWitness::from_stage_1(witness, &system);
+        let f = Val::from_u32;
+        let claim = &[f(0), f(4), f(1)];
+        let proof = system.prove(&key, claim, witness);
+        assert_eq!(proof.active, vec![true, true, false]);
+        assert_eq!(proof.log_degrees.len(), 2);
+        assert_eq!(proof.intermediate_accumulators.len(), 2);
+        assert_eq!(proof.stage_1_opened_values.len(), 2);
+        system.verify(claim, &proof).unwrap();
+    }
+
+    /// Tampering with the activation bitmap must be rejected: activating a
+    /// circuit the proof carries no data for, or deactivating one it does.
+    #[test]
+    fn sparse_bitmap_tamper_rejected() {
+        let config = GoldilocksBlake3Config::new(COMMITMENT_PARAMETERS, FRI_PARAMETERS);
+        let even = LookupAir::new(CS::Even, CS::Even.lookups());
+        let odd = LookupAir::new(CS::Odd, CS::Odd.lookups());
+        let dead = LookupAir::new(CS::Dead, CS::Dead.lookups());
+        let (system, key) = System::new(config, [even, odd, dead]);
+        let mut witness = witness_traces();
+        witness.push(RowMajorMatrix::new(vec![], 6));
+        let witness = SystemWitness::from_stage_1(witness, &system);
+        let f = Val::from_u32;
+        let claim = &[f(0), f(4), f(1)];
+        let mut proof = system.prove(&key, claim, witness);
+        proof.active[2] = true;
+        assert!(system.verify(claim, &proof).is_err());
+        proof.active[2] = false;
+        proof.active[1] = false;
+        assert!(system.verify(claim, &proof).is_err());
+    }
+
+    /// Deactivating a circuit the claim's execution NEEDS (here: emptying the
+    /// Odd table while Even still pushes into the odd channel) must leave the
+    /// lookup accumulator unbalanced and be rejected.
+    #[test]
+    fn sparse_needed_circuit_rejected() {
+        let (system, key) = system();
+        let mut traces = witness_traces();
+        // Empty the Odd table: Even's pushes into the odd channel and the
+        // claim's pull can no longer be matched.
+        traces[1] = RowMajorMatrix::new(vec![], 6);
+        let witness = SystemWitness::from_stage_1(traces, &system);
+        let f = Val::from_u32;
+        let claim = &[f(0), f(4), f(1)];
+        let proof = system.prove(&key, claim, witness);
+        assert_eq!(proof.active, vec![true, false]);
+        assert!(system.verify(claim, &proof).is_err());
     }
 
     #[test]

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -7,6 +7,12 @@
 //! (circuit count, widths, constraint counts, degrees)
 //! is observed before any commitment.
 //!
+//! 0. **Sparse activation**: circuits whose stage-1 trace is empty are
+//!    deactivated for this proof — skipped by every stage below — and the
+//!    activation bitmap over the canonical circuit set is observed
+//!    immediately after the shape, before any commitment or challenge. See
+//!    [`Proof::active`] for the soundness contract.
+//!
 //! 1. **Stage 1 — Main traces**: Each circuit's execution trace is committed via the
 //!    configuration's PCS. The preprocessed commitment (if any), stage-1 commitment,
 //!    trace heights, and length-prefixed claims are observed into the challenger.
@@ -196,10 +202,21 @@ pub struct Commitments<Com> {
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct Proof<SC: StarkGenericConfig> {
+    /// Activation bitmap over the system's canonical circuit set: circuit i
+    /// is covered by this proof iff `active[i]`. Inactive circuits (empty
+    /// execution traces) are not committed, opened, accumulated, or
+    /// constraint-evaluated; the lookup accumulator polices dishonest
+    /// deactivation (an omitted-but-needed circuit leaves an unmatched
+    /// channel send, so the final accumulator cannot be zero). Bound into
+    /// the Fiat-Shamir transcript before any commitment or challenge.
+    /// Every other per-circuit sequence in this proof (accumulators,
+    /// log_degrees, opened values) is indexed by ACTIVE position.
+    pub active: Vec<bool>,
     pub commitments: Commitments<Com<SC>>,
-    /// Per-circuit intermediate accumulator values for the lookup argument.
+    /// Per-active-circuit intermediate accumulator values for the lookup
+    /// argument.
     pub intermediate_accumulators: Vec<SC::Challenge>,
-    /// Log2 of the trace degree for each circuit.
+    /// Log2 of the trace degree for each active circuit.
     pub log_degrees: Vec<u8>,
     /// PCS opening proof covering all rounds.
     pub opening_proof: PcsProof<SC>,
@@ -247,6 +264,14 @@ where
     ///
     /// Each claim is a slice of field elements that is observed by the challenger
     /// before lookup challenges are sampled, binding the proof to the claimed values.
+    ///
+    /// Circuits whose stage-1 trace is empty are deactivated for this proof:
+    /// they are neither committed, opened, accumulated, nor
+    /// constraint-evaluated, and the activation bitmap is recorded in
+    /// [`Proof::active`].
+    ///
+    /// # Panics
+    /// Panics if every circuit's trace is empty (nothing to prove).
     #[tracing::instrument(level = "info", skip_all, name = "stark/prove")]
     pub fn prove_multiple_claims(
         &self,
@@ -262,17 +287,52 @@ where
         // are already bound via the challenger seed.
         self.observe_shape(&mut challenger);
 
+        // Sparse activation: a circuit whose stage-1 trace is empty is
+        // INACTIVE for this proof — nothing of it is committed, opened,
+        // accumulated, or constraint-evaluated. Soundness of the omission
+        // rests on the lookup accumulator: an inactive circuit has no rows,
+        // hence no sends or receives, so omitting it leaves the global
+        // balance unchanged — while dishonestly deactivating a circuit the
+        // execution needs leaves an unmatched channel send and the final
+        // accumulator cannot be zero. The activation bitmap is bound into
+        // the transcript here, before any commitment or challenge.
+        let active: Vec<bool> = witness.traces.iter().map(|t| t.height() > 0).collect();
+        for &is_active in &active {
+            challenger.observe(Val::<SC>::from_bool(is_active));
+        }
+        // Canonical index of each active circuit, in order; matrix position
+        // within every per-proof commitment == position in this list.
+        let active_indices: Vec<usize> = active
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &a)| a.then_some(i))
+            .collect();
+        assert!(
+            !active_indices.is_empty(),
+            "cannot prove with every circuit deactivated (all traces empty)"
+        );
+        // Canonical index -> active position (None = inactive).
+        let mut active_pos: Vec<Option<usize>> = vec![None; active.len()];
+        for (pos, &ci) in active_indices.iter().enumerate() {
+            active_pos[ci] = Some(pos);
+        }
+
         // Cost: "Stage 1 commit" — coset LDE (FFT) of each trace from n_i to
         // n_i·B rows, then Merkle tree. FFT work: Σ w_i · n_i · B · log₂(n_i·B).
         let _g = tracing::info_span!("stark/stage1_commit").entered();
         let mut log_degrees = vec![];
-        let evaluations = witness.traces.into_iter().map(|trace| {
-            let degree = trace.height();
-            let log_degree = log2_strict_usize(degree);
-            let trace_domain = pcs.natural_domain_for_degree(degree);
-            log_degrees.push(log_degree);
-            (trace_domain, trace)
-        });
+        let evaluations = witness
+            .traces
+            .into_iter()
+            .zip(active.clone())
+            .filter_map(|(trace, is_active)| is_active.then_some(trace))
+            .map(|trace| {
+                let degree = trace.height();
+                let log_degree = log2_strict_usize(degree);
+                let trace_domain = pcs.natural_domain_for_degree(degree);
+                log_degrees.push(log_degree);
+                (trace_domain, trace)
+            });
         let (stage_1_trace_commit, stage_1_trace_data) = pcs.commit(evaluations);
         drop(_g);
 
@@ -315,8 +375,16 @@ where
         // Cost: "Lookup trace construction" — fingerprint (Horner), batch
         // inversion, and accumulator update. Total: Σ n_i·L_i extension field ops.
         let _g = tracing::info_span!("stark/lookup_construction").entered();
+        // Only active circuits enter the accumulator chain; the chain (and
+        // `intermediate_accumulators`) is indexed by active position.
+        let active_lookups: Vec<_> = witness
+            .lookups
+            .into_iter()
+            .zip(&active)
+            .filter_map(|(l, &is_active)| is_active.then_some(l))
+            .collect();
         let (stage_2_traces, intermediate_accumulators) = Lookup::stage_2_traces(
-            &witness.lookups,
+            &active_lookups,
             lookup_argument_challenge,
             &fingerprint_challenge,
             acc,
@@ -349,16 +417,16 @@ where
         // quotient domain (Σ n_i·q_i·eval_cost(k_i)) plus LDE + Merkle of the
         // quotient sub-polynomials (Σ q_i·D·n_i·B·log₂(n_i·B)).
         let _g = tracing::info_span!("stark/quotient").entered();
-        debug_assert_eq!(intermediate_accumulators.len(), self.circuits.len());
-        debug_assert_eq!(log_degrees.len(), self.circuits.len());
+        debug_assert_eq!(intermediate_accumulators.len(), active_indices.len());
+        debug_assert_eq!(log_degrees.len(), active_indices.len());
         let mut quotient_degrees = vec![];
-        let quotient_evaluations = self
-            .circuits
+        let quotient_evaluations = active_indices
             .iter()
             .zip(log_degrees.iter())
             .zip(intermediate_accumulators.iter())
             .enumerate()
-            .flat_map(|(idx, ((circuit, log_degree), next_acc))| {
+            .flat_map(|(pos, ((&ci, log_degree), next_acc))| {
+                let circuit = &self.circuits[ci];
                 let air = &circuit.air;
                 let quotient_degree = circuit.quotient_degree();
                 let log_quotient_degree = log2_strict_usize(quotient_degree);
@@ -368,7 +436,7 @@ where
                 let preprocessed_trace_on_quotient_domain = key
                     .preprocessed_data
                     .as_ref()
-                    .zip(self.preprocessed_indices[idx])
+                    .zip(self.preprocessed_indices[ci])
                     .map(|(preprocessed_trace_data, preprocessed_idx)| {
                         pcs.get_evaluations_on_domain(
                             preprocessed_trace_data,
@@ -377,9 +445,9 @@ where
                         )
                     });
                 let stage_1_trace_on_quotient_domain =
-                    pcs.get_evaluations_on_domain(&stage_1_trace_data, idx, quotient_domain);
+                    pcs.get_evaluations_on_domain(&stage_1_trace_data, pos, quotient_domain);
                 let stage_2_trace_on_quotient_domain =
-                    pcs.get_evaluations_on_domain(&stage_2_trace_data, idx, quotient_domain);
+                    pcs.get_evaluations_on_domain(&stage_2_trace_data, pos, quotient_domain);
                 // compute the quotient values which are elements of the extension field and flatten it to the base field
                 let public_values: [Val<SC>; 0] = [];
                 let stage_2_public_values = [
@@ -433,9 +501,9 @@ where
         let mut round1_openings = vec![];
         let mut round2_openings = vec![];
         let mut round3_openings = vec![];
-        for i in 0..self.circuits.len() {
-            let log_degree = log_degrees[i];
-            let quotient_degree = quotient_degrees[i];
+        for pos in 0..active_indices.len() {
+            let log_degree = log_degrees[pos];
+            let quotient_degree = quotient_degrees[pos];
             let trace_domain = pcs.natural_domain_for_degree(1 << log_degree);
             let zeta_next = trace_domain
                 .next_point(zeta)
@@ -443,8 +511,23 @@ where
             round1_openings.push(vec![zeta, zeta_next]);
             round2_openings.push(vec![zeta, zeta_next]);
             round3_openings.extend(vec![vec![zeta]; quotient_degree]);
-            if self.preprocessed_indices[i].is_some() {
-                round0_openings.push(vec![zeta, zeta_next]);
+        }
+        // The preprocessed commitment is built once over ALL preprocessed
+        // traces at system construction, so its round must carry one entry
+        // per preprocessed matrix regardless of activation: an inactive
+        // circuit's preprocessed matrix is opened at no points.
+        for (prep_index, &pos) in self.preprocessed_indices.iter().zip(&active_pos) {
+            if prep_index.is_some() {
+                match pos {
+                    Some(pos) => {
+                        let trace_domain = pcs.natural_domain_for_degree(1 << log_degrees[pos]);
+                        let zeta_next = trace_domain
+                            .next_point(zeta)
+                            .expect("domain has no next point");
+                        round0_openings.push(vec![zeta, zeta_next]);
+                    }
+                    None => round0_openings.push(vec![]),
+                }
             }
         }
         let mut rounds = vec![
@@ -468,6 +551,7 @@ where
             .map(|n| n.try_into().unwrap())
             .collect();
         Proof {
+            active,
             commitments,
             intermediate_accumulators,
             log_degrees,

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -2,24 +2,26 @@
 //!
 //! # Verification steps
 //!
-//! 1. **Shape check** ([`System::verify_shape`]): Validate that the proof's array
-//!    dimensions (opened values, accumulators, quotient chunks) match the system's
-//!    circuit count and column widths.
+//! 1. **Shape check** ([`System::verify_shape`]): Validate the activation bitmap
+//!    (it must cover the canonical circuit set and activate at least one circuit)
+//!    and that the proof's array dimensions (opened values, accumulators, quotient
+//!    chunks) match the ACTIVE circuit count and the canonical column widths.
 //!
 //! 2. **Accumulator balance**: Assert that the last intermediate accumulator is zero,
 //!    ensuring that all lookup pushes and pulls cancel out across circuits.
 //!
 //! 3. **Fiat-Shamir replay**: Reconstruct the challenger state identically to the
 //!    prover: starting from the parameter-seeded challenger, observe the system
-//!    shape, commitments, trace heights, length-prefixed claims, and intermediate
-//!    accumulators, sampling the same challenges (lookup, fingerprint, constraint
-//!    alpha, OOD zeta) at the same points in the transcript.
+//!    shape, the activation bitmap, commitments, trace heights, length-prefixed
+//!    claims, and intermediate accumulators, sampling the same challenges (lookup,
+//!    fingerprint, constraint alpha, OOD zeta) at the same points in the
+//!    transcript.
 //!
 //! 4. **PCS verification**: Verify the FRI opening proofs against the committed
 //!    polynomials at the sampled points.
 //!
-//! 5. **OOD evaluation**: For each circuit, recompute the composition polynomial at
-//!    zeta from the opened values and verify that
+//! 5. **OOD evaluation**: For each ACTIVE circuit, recompute the composition
+//!    polynomial at zeta from the opened values and verify that
 //!    `composition(zeta) * inv_vanishing(zeta) == quotient(zeta)`.
 //!
 //! See [`VerificationError`] for the possible failure modes.
@@ -123,6 +125,26 @@
 //! security (≈ 50 bits proven) from FRI alone, plus additional grinding cost from
 //! PoW.
 //!
+//! ## Sparse activation
+//!
+//! A proof covers only the circuits its activation bitmap marks active
+//! ([`Proof::active`]); inactive circuits are neither committed, opened,
+//! accumulated, nor constraint-evaluated. An accepted sparse proof is
+//! equivalent to a dense proof in which every inactive circuit has an empty
+//! table: an inactive circuit contributes no lookup sends or receives, so
+//! honest deactivation leaves the global balance unchanged, while
+//! dishonestly deactivating a circuit the execution needs leaves an
+//! unmatched channel message and the final accumulator is a nonzero
+//! rational function of (β, γ) — caught by the balance check with the same
+//! N / |F_ext| bound as above. The bitmap cannot be chosen adaptively: it
+//! is observed before any commitment or challenge, and the verifier takes
+//! every active circuit's widths, constraints, and lookup structure from
+//! the canonical system by bitmap index. The one contract change relative
+//! to dense proofs: an AIR can no longer force its own presence through
+//! must-hold padding rows — sparse verification guarantees the constraints
+//! of ACTIVE circuits plus global lookup balance, and nothing about
+//! inactive ones.
+//!
 //! ## Not zero-knowledge
 //!
 //! This protocol is a succinct argument of knowledge, **not** a zero-knowledge
@@ -189,6 +211,7 @@ where
         proof: &Proof<SC>,
     ) -> Result<(), VerificationError<PcsError<SC>>> {
         let Proof {
+            active,
             commitments,
             intermediate_accumulators,
             log_degrees,
@@ -198,8 +221,15 @@ where
             stage_1_opened_values,
             stage_2_opened_values,
         } = proof;
-        // first, verify the proof shape
+        // first, verify the proof shape (also validates the activation bitmap)
         let quotient_degrees = self.verify_shape(proof)?;
+        // Canonical index of each active circuit; every per-circuit sequence
+        // in the proof is indexed by position in this list.
+        let active_indices: Vec<usize> = active
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &a)| a.then_some(i))
+            .collect();
 
         // Soundness: lookup argument. The accumulator was computed by the prover
         // under challenges (β, γ) that were sampled after the traces and claims were
@@ -224,6 +254,12 @@ where
         // Bind the system shape into the transcript. The protocol parameters
         // are already bound via the challenger seed.
         self.observe_shape(&mut challenger);
+
+        // Bind the activation bitmap — before any commitment or challenge, so
+        // every sample depends on which circuits this proof covers.
+        for &is_active in active {
+            challenger.observe(Val::<SC>::from_bool(is_active));
+        }
 
         // observe preprocessed and stage_1 commitment
         if let Some(commit) = &self.preprocessed_commit {
@@ -285,14 +321,13 @@ where
         // Soundness: OOD evaluation. ζ is sampled after all commitments are fixed.
         // A nonzero polynomial of degree ≤ D vanishes at ζ with probability ≤ D/|F_ext|.
         let zeta: SC::Challenge = challenger.sample_algebra_element();
-        let mut preprocessed_trace_evaluations = vec![];
         let mut stage_1_trace_evaluations = vec![];
         let mut stage_2_trace_evaluations = vec![];
         let mut quotient_chunks_evaluations = vec![];
         let mut last_quotient_i = 0;
-        for i in 0..self.circuits.len() {
-            let log_degree = log_degrees[i];
-            let quotient_degree = quotient_degrees[i];
+        for pos in 0..active_indices.len() {
+            let log_degree = log_degrees[pos];
+            let quotient_degree = quotient_degrees[pos];
             let log_quotient_degree = log2_strict_usize(quotient_degree);
             let trace_domain = pcs.natural_domain_for_degree(1 << log_degree);
             let quotient_domain =
@@ -305,28 +340,18 @@ where
             let zeta_next = trace_domain
                 .next_point(zeta)
                 .ok_or(VerificationError::InvalidProofShape)?;
-            if let Some(i) = self.preprocessed_indices[i] {
-                let preprocessed_opened_values = preprocessed_opened_values.as_ref().unwrap();
-                preprocessed_trace_evaluations.push((
-                    trace_domain,
-                    vec![
-                        (zeta, preprocessed_opened_values[i][0].clone()),
-                        (zeta_next, preprocessed_opened_values[i][1].clone()),
-                    ],
-                ));
-            }
             stage_1_trace_evaluations.push((
                 trace_domain,
                 vec![
-                    (zeta, stage_1_opened_values[i][0].clone()),
-                    (zeta_next, stage_1_opened_values[i][1].clone()),
+                    (zeta, stage_1_opened_values[pos][0].clone()),
+                    (zeta_next, stage_1_opened_values[pos][1].clone()),
                 ],
             ));
             stage_2_trace_evaluations.push((
                 trace_domain,
                 vec![
-                    (zeta, stage_2_opened_values[i][0].clone()),
-                    (zeta_next, stage_2_opened_values[i][1].clone()),
+                    (zeta, stage_2_opened_values[pos][0].clone()),
+                    (zeta_next, stage_2_opened_values[pos][1].clone()),
                 ],
             ));
             let iter = unshifted_quotient_chunks_domains
@@ -338,6 +363,42 @@ where
                 .map(|(domain, opened_values)| (domain, vec![(zeta, opened_values[0].clone())]));
             quotient_chunks_evaluations.extend(iter);
             last_quotient_i += quotient_degree;
+        }
+        // The preprocessed commitment covers ALL preprocessed matrices, in
+        // canonical slot order; inactive circuits' matrices are opened at no
+        // points (mirroring the prover's round construction).
+        let mut preprocessed_trace_evaluations = vec![];
+        {
+            let mut active_pos: Vec<Option<usize>> = vec![None; active.len()];
+            for (pos, &ci) in active_indices.iter().enumerate() {
+                active_pos[ci] = Some(pos);
+            }
+            for (ci, &slot) in self.preprocessed_indices.iter().enumerate() {
+                if let Some(slot) = slot {
+                    match active_pos[ci] {
+                        Some(pos) => {
+                            let trace_domain = pcs.natural_domain_for_degree(1 << log_degrees[pos]);
+                            let zeta_next = trace_domain
+                                .next_point(zeta)
+                                .ok_or(VerificationError::InvalidProofShape)?;
+                            let preprocessed_opened_values =
+                                preprocessed_opened_values.as_ref().unwrap();
+                            preprocessed_trace_evaluations.push((
+                                trace_domain,
+                                vec![
+                                    (zeta, preprocessed_opened_values[slot][0].clone()),
+                                    (zeta_next, preprocessed_opened_values[slot][1].clone()),
+                                ],
+                            ));
+                        }
+                        None => {
+                            let domain = pcs
+                                .natural_domain_for_degree(self.circuits[ci].preprocessed_height);
+                            preprocessed_trace_evaluations.push((domain, vec![]));
+                        }
+                    }
+                }
+            }
         }
         let mut coms_to_verify = vec![
             (commitments.stage_1_trace.clone(), stage_1_trace_evaluations),
@@ -364,15 +425,15 @@ where
         // and check that the evaluation of the composition polynomial equals the
         // product of the zerofier with the quotient
         let mut last_quotient_i = 0;
-        for i in 0..self.circuits.len() {
-            let circuit = &self.circuits[i];
-            let degree = 1 << log_degrees[i];
-            let quotient_degree = quotient_degrees[i];
-            let next_acc = intermediate_accumulators[i];
-            let stage_1_row = &stage_1_opened_values[i][0];
-            let stage_1_next_row = &stage_1_opened_values[i][1];
-            let stage_2_row = &stage_2_opened_values[i][0];
-            let stage_2_next_row = &stage_2_opened_values[i][1];
+        for (pos, &ci) in active_indices.iter().enumerate() {
+            let circuit = &self.circuits[ci];
+            let degree = 1 << log_degrees[pos];
+            let quotient_degree = quotient_degrees[pos];
+            let next_acc = intermediate_accumulators[pos];
+            let stage_1_row = &stage_1_opened_values[pos][0];
+            let stage_1_next_row = &stage_1_opened_values[pos][1];
+            let stage_2_row = &stage_2_opened_values[pos][0];
+            let stage_2_next_row = &stage_2_opened_values[pos][1];
             let quotient_chunks = quotient_opened_values
                 [last_quotient_i..last_quotient_i + quotient_degree]
                 .iter()
@@ -382,10 +443,10 @@ where
             // compute the composition polynomial evaluation
             let trace_domain = pcs.natural_domain_for_degree(degree);
             let sels = trace_domain.selectors_at_point(zeta);
-            let preprocessed = if let Some(i) = self.preprocessed_indices[i] {
+            let preprocessed = if let Some(slot) = self.preprocessed_indices[ci] {
                 let preprocessed_opened_values = preprocessed_opened_values.as_ref().unwrap();
-                let preprocessed_row = &preprocessed_opened_values[i][0];
-                let preprocessed_next_row = &preprocessed_opened_values[i][1];
+                let preprocessed_row = &preprocessed_opened_values[slot][0];
+                let preprocessed_next_row = &preprocessed_opened_values[slot][1];
                 RowWindow::from_two_rows(preprocessed_row, preprocessed_next_row)
             } else {
                 RowWindow::from_two_rows(&[], &[])
@@ -479,6 +540,7 @@ where
         proof: &Proof<SC>,
     ) -> Result<Vec<usize>, VerificationError<PcsError<SC>>> {
         let Proof {
+            active,
             intermediate_accumulators,
             log_degrees,
             quotient_opened_values,
@@ -491,10 +553,24 @@ where
         let num_circuits = self.circuits.len();
         // there must be at least one circuit
         ensure!(num_circuits > 0, VerificationError::InvalidSystem);
-        // there must be one log degree per circuit
+        // the activation bitmap covers the canonical circuit set
+        ensure_eq!(
+            active.len(),
+            num_circuits,
+            VerificationError::InvalidProofShape
+        );
+        let active_indices: Vec<usize> = active
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &a)| a.then_some(i))
+            .collect();
+        let num_active = active_indices.len();
+        // an empty activation proves nothing
+        ensure!(num_active > 0, VerificationError::InvalidProofShape);
+        // there must be one log degree per active circuit
         ensure_eq!(
             log_degrees.len(),
-            num_circuits,
+            num_active,
             VerificationError::InvalidProofShape
         );
         // the preprocessed commitment is empty if and only if there are zero preprocessed circuits
@@ -508,7 +584,10 @@ where
             num_preprocessed == 0,
             VerificationError::InvalidSystem
         );
-        // stage 0 round
+        // Stage 0 round: the preprocessed commitment is built once over ALL
+        // preprocessed traces at system construction, so its round carries one
+        // entry per preprocessed matrix regardless of activation; an inactive
+        // circuit's matrix must be opened at no points.
         ensure_eq!(
             preprocessed_opened_values
                 .as_ref()
@@ -516,57 +595,76 @@ where
             num_preprocessed,
             VerificationError::InvalidProofShape
         );
-        // stage 1 round
+        for (&prep_index, &is_active) in self.preprocessed_indices.iter().zip(active) {
+            if let Some(slot) = prep_index
+                && !is_active
+            {
+                ensure_eq!(
+                    preprocessed_opened_values.as_ref().unwrap()[slot].len(),
+                    0,
+                    VerificationError::InvalidProofShape
+                );
+            }
+        }
+        // stage 1 round: one entry per active circuit
         ensure_eq!(
             stage_1_opened_values.len(),
-            num_circuits,
+            num_active,
             VerificationError::InvalidProofShape
         );
-        // stage 2 round
+        // stage 2 round: one entry per active circuit
         ensure_eq!(
             stage_2_opened_values.len(),
-            num_circuits,
+            num_active,
             VerificationError::InvalidProofShape
         );
-        for (i, circuit) in self.circuits.iter().enumerate() {
-            let preprocessed_i = self.preprocessed_indices[i];
+        for (pos, &ci) in active_indices.iter().enumerate() {
+            let circuit = &self.circuits[ci];
+            let preprocessed_i = self.preprocessed_indices[ci];
             // zeta and zeta_next
             let num_openings = 2;
             ensure_eq!(
-                stage_1_opened_values[i].len(),
+                stage_1_opened_values[pos].len(),
                 num_openings,
                 VerificationError::InvalidProofShape
             );
             ensure_eq!(
-                stage_2_opened_values[i].len(),
+                stage_2_opened_values[pos].len(),
                 num_openings,
                 VerificationError::InvalidProofShape
             );
+            if let Some(slot) = preprocessed_i {
+                ensure_eq!(
+                    preprocessed_opened_values.as_ref().unwrap()[slot].len(),
+                    num_openings,
+                    VerificationError::InvalidProofShape
+                );
+            }
             for j in 0..num_openings {
-                if let Some(i) = preprocessed_i {
+                if let Some(slot) = preprocessed_i {
                     ensure_eq!(
-                        preprocessed_opened_values.as_ref().unwrap()[i][j].len(),
+                        preprocessed_opened_values.as_ref().unwrap()[slot][j].len(),
                         circuit.preprocessed_width,
                         VerificationError::InvalidProofShape
                     );
                 }
                 ensure_eq!(
-                    stage_1_opened_values[i][j].len(),
+                    stage_1_opened_values[pos][j].len(),
                     circuit.stage_1_width,
                     VerificationError::InvalidProofShape
                 );
                 let extension_d = <SC::Challenge as BasedVectorSpace<Val<SC>>>::DIMENSION;
                 ensure_eq!(
-                    stage_2_opened_values[i][j].len(),
+                    stage_2_opened_values[pos][j].len(),
                     circuit.stage_2_width * extension_d,
                     VerificationError::InvalidProofShape
                 );
             }
         }
-        // quotient round
+        // quotient round: per active circuit
         let mut quotient_degrees = vec![];
-        for (circuit, log_degree) in self.circuits.iter().zip(log_degrees) {
-            let quotient_degree = circuit.quotient_degree();
+        for (&ci, log_degree) in active_indices.iter().zip(log_degrees) {
+            let quotient_degree = self.circuits[ci].quotient_degree();
             // The claimed log degree must be small enough that the quotient
             // domain can still be committed and opened by the PCS. This also
             // guards the `1 << log_degree` shifts used during verification
@@ -599,10 +697,10 @@ where
                 VerificationError::InvalidProofShape
             );
         }
-        // there must be as many intermediate accumulators as circuits
+        // there must be as many intermediate accumulators as active circuits
         ensure_eq!(
             intermediate_accumulators.len(),
-            self.circuits.len(),
+            num_active,
             VerificationError::InvalidProofShape
         );
         Ok(quotient_degrees)


### PR DESCRIPTION
A system declares a canonical circuit set; a proof now activates only a subset. A circuit whose stage-1 trace is empty is INACTIVE: it is not committed, not opened, contributes no accumulator entry, and its constraints are not evaluated. The activation bitmap is a new leading Proof field, bound into the Fiat-Shamir transcript immediately after observe_shape — before any commitment or challenge — so every sample depends on which circuits the proof covers.

Soundness reduces to the existing lookup-accumulator argument: an accepted sparse proof is equivalent to a dense proof in which every inactive circuit has an empty table. An inactive circuit has no rows, hence no sends or receives, so honest deactivation leaves the global balance unchanged; dishonestly deactivating a circuit the execution needs leaves an unmatched channel send (only the canonical circuit for a channel can answer it — the verifier takes widths, AIRs, and lookup structure from the canonical system by bitmap index), making the final accumulator a nonzero rational function of the lookup challenges (Schwartz-Zippel as before). Activating extra circuits grants nothing a dense prover did not already have. The one contract change: an AIR can no longer force its own presence via must-hold padding rows — sparse soundness guarantees constraints of ACTIVE circuits plus global balance, and nothing about inactive ones.

Every per-circuit sequence in the proof (log_degrees, accumulators, opened-value rounds) is indexed by active position; the verifier's shape check validates the bitmap and count consistency. The preprocessed commitment — built once over all preprocessed traces at system construction — keeps one round entry per preprocessed matrix regardless of activation; an inactive circuit's matrix is opened at no points.

Tests: a three-circuit system with an unreferenced dead circuit proves and verifies with active = [true, true, false] and two-entry per-proof sequences; tampering with the bitmap in either direction is rejected; deactivating a circuit the claim's execution needs (emptying the Odd table while Even still pushes into its channel) is rejected as unbalanced. All 23 pre-existing tests pass unchanged (all-active proofs are the dense special case).