### PR TITLE
bench: Add texray span output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "blake3"
 version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,10 +261,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
 
 [[package]]
 name = "getrandom"
@@ -335,10 +366,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -347,6 +390,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -379,6 +450,17 @@ dependencies = [
  "rand",
  "serde",
  "tracing",
+ "tracing-subscriber",
+ "tracing-texray",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -692,6 +774,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +898,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +936,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,6 +962,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -886,10 +1019,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "spin"
@@ -918,6 +1066,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +1093,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -985,6 +1152,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracing-texray"
+version = "0.2.0"
+source = "git+https://github.com/argumentcomputer/tracing-texray?rev=465bbca0bea4721e58419c11cabd8cce21757822#465bbca0bea4721e58419c11cabd8cce21757822"
+dependencies = [
+ "loom",
+ "parking_lot",
+ "terminal_size",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1008,6 +1217,12 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "virtue"
@@ -1094,6 +1309,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ p3-util = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b
 criterion = "0.5"
 p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3", rev = "e9d75614dd6816f9b5dbb4413c69be63536efd64" }
 rand = "0.10"
+tracing-subscriber = "0.3"
+tracing-texray = { git = "https://github.com/argumentcomputer/tracing-texray", rev = "465bbca0bea4721e58419c11cabd8cce21757822" }
 
 [[bench]]
 name = "multi_stark"

--- a/benches/multi_stark.rs
+++ b/benches/multi_stark.rs
@@ -11,11 +11,18 @@
 //! ```sh
 //! cargo bench --bench multi_stark --features parallel
 //! ```
+//!
+//! Before each criterion measurement, one prove/verify runs under a
+//! `tracing-texray`-examined span: every `info_span!` in the prover streams
+//! a `[texray] <span>: <dur>  ── RAM Δ +X peak Y` line to stderr as it
+//! closes, followed by the full span-tree timeline when the root exits.
+//! By default only multi-stark's `stark/*` spans are rendered; set
+//! `TEXRAY_PREFIXES=` (empty) to also render Plonky3's internal spans.
 
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group};
 use multi_stark::builder::symbolic::{SymbolicExpression, preprocessed_var, var};
 use multi_stark::lookup::{Lookup, LookupAir};
-use multi_stark::system::{System, SystemWitness};
+use multi_stark::system::{ProverKey, System, SystemWitness};
 use multi_stark::types::{CommitmentParameters, FriParameters, GoldilocksBlake3Config, Val};
 use multi_stark::{
     p3_air::{Air, AirBuilder, BaseAir, WindowAccess},
@@ -24,6 +31,40 @@ use multi_stark::{
 };
 
 type SymbExpr = SymbolicExpression<Val>;
+
+/// Install `tracing-texray` as the global subscriber, with per-span RAM
+/// sampling and streaming output.
+///
+/// Spans are filtered by name prefix, like Ix's `rs_texray_init`:
+/// `TEXRAY_PREFIXES` is a comma-separated list of span-name prefixes to
+/// render, defaulting to `stark/,bench/` (multi-stark's own spans only).
+/// An explicitly empty list (`TEXRAY_PREFIXES=`) disables filtering and
+/// renders everything — including Plonky3's internal spans at every level
+/// (FRI folds, merkle-tree builds, per-matrix DFTs, …).
+fn init_texray() {
+    use tracing_subscriber::{
+        Layer, Registry, filter::FilterFn, layer::SubscriberExt, util::SubscriberInitExt,
+    };
+    let prefixes: Vec<String> = std::env::var("TEXRAY_PREFIXES")
+        .unwrap_or_else(|_| "stark/,bench/".to_string())
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect();
+    let layer = tracing_texray::TeXRayLayer::new().track_ram().streaming();
+    let filter = FilterFn::new(move |metadata| {
+        if !metadata.is_span() || prefixes.is_empty() {
+            return true;
+        }
+        let name = metadata.name();
+        prefixes.iter().any(|p| name.starts_with(p.as_str()))
+    });
+    Registry::default()
+        .with(layer.with_filter(filter))
+        .try_init()
+        .ok();
+}
 
 // ---------------------------------------------------------------------------
 // Circuits
@@ -203,10 +244,10 @@ fn build_claims(num_adds: usize) -> Vec<[Val; 4]> {
 // Benchmarks
 // ---------------------------------------------------------------------------
 
-fn bench_prove(c: &mut Criterion) {
-    let config = GoldilocksBlake3Config::new(
+fn bench_config() -> GoldilocksBlake3Config {
+    GoldilocksBlake3Config::new(
         CommitmentParameters {
-            log_blowup: 1,
+            log_blowup: 2,
             cap_height: 0,
         },
         FriParameters {
@@ -216,10 +257,20 @@ fn bench_prove(c: &mut Criterion) {
             commit_proof_of_work_bits: 10,
             query_proof_of_work_bits: 10,
         },
-    );
+    )
+}
+
+fn build_system() -> (
+    System<GoldilocksBlake3Config, U32CS>,
+    ProverKey<GoldilocksBlake3Config>,
+) {
     let byte_table = LookupAir::new(U32CS::ByteTable, U32CS::ByteTable.lookups());
     let u32_add = LookupAir::new(U32CS::U32Add, U32CS::U32Add.lookups());
-    let (system, key) = System::new(config, [byte_table, u32_add]);
+    System::new(bench_config(), [byte_table, u32_add])
+}
+
+fn bench_prove(c: &mut Criterion) {
+    let (system, key) = build_system();
 
     let mut group = c.benchmark_group("prove");
     group.sample_size(10);
@@ -229,6 +280,15 @@ fn bench_prove(c: &mut Criterion) {
         let num_adds = 1 << log_height;
         let claims = build_claims(num_adds);
         let claim_refs: Vec<&[Val]> = claims.iter().map(|c| c.as_slice()).collect();
+
+        // One examined proof outside the measurement loop; spans opened during
+        // criterion's iterations have no examined root and print nothing.
+        let witness = build_witness(num_adds, &system);
+        eprintln!("\n═══ texray: prove/u32_add/2^{log_height} (single traced run) ═══");
+        tracing_texray::examine(tracing::info_span!("bench/prove", log_height))
+            .in_scope(|| system.prove_multiple_claims(&key, &claim_refs, witness));
+        eprintln!();
+
         group.bench_function(
             BenchmarkId::new("u32_add", format!("2^{log_height}")),
             |b| {
@@ -244,22 +304,7 @@ fn bench_prove(c: &mut Criterion) {
 }
 
 fn bench_verify(c: &mut Criterion) {
-    let config = GoldilocksBlake3Config::new(
-        CommitmentParameters {
-            log_blowup: 1,
-            cap_height: 0,
-        },
-        FriParameters {
-            log_final_poly_len: 0,
-            max_log_arity: 1,
-            num_queries: 100,
-            commit_proof_of_work_bits: 10,
-            query_proof_of_work_bits: 10,
-        },
-    );
-    let byte_table = LookupAir::new(U32CS::ByteTable, U32CS::ByteTable.lookups());
-    let u32_add = LookupAir::new(U32CS::U32Add, U32CS::U32Add.lookups());
-    let (system, key) = System::new(config, [byte_table, u32_add]);
+    let (system, key) = build_system();
 
     let mut group = c.benchmark_group("verify");
     group.sample_size(10);
@@ -271,6 +316,12 @@ fn bench_verify(c: &mut Criterion) {
         let claim_refs: Vec<&[Val]> = claims.iter().map(|c| c.as_slice()).collect();
         let witness = build_witness(num_adds, &system);
         let proof = system.prove_multiple_claims(&key, &claim_refs, witness);
+
+        eprintln!("\n═══ texray: verify/u32_add/2^{log_height} (single traced run) ═══");
+        tracing_texray::examine(tracing::info_span!("bench/verify", log_height))
+            .in_scope(|| system.verify_multiple_claims(&claim_refs, &proof).unwrap());
+        eprintln!();
+
         group.bench_function(
             BenchmarkId::new("u32_add", format!("2^{log_height}")),
             |b| {
@@ -282,4 +333,11 @@ fn bench_verify(c: &mut Criterion) {
 }
 
 criterion_group!(benches, bench_prove, bench_verify);
-criterion_main!(benches);
+
+// Expanded `criterion_main!` so the texray subscriber installs before any
+// span is created.
+fn main() {
+    init_texray();
+    benches();
+    Criterion::default().configure_from_args().final_summary();
+}


### PR DESCRIPTION
- Adds a texray tracing subscriber to print a timing graph and peak RAM usage per span
- Adds a `TEXRAY_PREFIXES` env var that tunes which spans are printed. By default just `stark/` and `bench/` prints from multi-stark, but unset `TEXRAY_PREFIXES=` to see the spans from Plonky3
- Changes log_blowup to 2 to match the Aiur use case