### PR TITLE
Quotient matrix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ rust-version = "1.91"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+# Standalone package: don't get absorbed by an enclosing workspace checkout.
+[workspace]
+
 [dependencies]
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -112,8 +112,10 @@
 //! obtained by subsetting the LDE (essentially free); otherwise an additional
 //! iFFT + FFT is required.
 //!
-//! The quotient polynomial is split into q_i sub-polynomials (each of degree
-//! n_i) and committed.
+//! The quotient polynomial is split into q_i coefficient slices (each of
+//! degree n_i) and committed as a single q_i·D-column matrix per circuit on
+//! the trace domain, so the opening phase pays its per-matrix costs once per
+//! circuit rather than once per slice.
 //!
 //! ```text
 //! Constraint eval:  Σ_i  n_i · q_i · eval_cost(k_i)         field operations
@@ -181,7 +183,8 @@ use bincode::{
 use p3_air::{Air, BaseAir, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{LagrangeSelectors, OpenedValuesForRound, Pcs, PolynomialSpace};
-use p3_field::{BasedVectorSpace, Field, PackedValue, PrimeCharacteristicRing};
+use p3_dft::{Radix2DitParallel, TwoAdicSubgroupDft};
+use p3_field::{BasedVectorSpace, Field, PackedValue, PrimeCharacteristicRing, TwoAdicField};
 use p3_matrix::{Matrix, dense::RowMajorMatrix};
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
@@ -246,6 +249,9 @@ impl<SC: StarkGenericConfig> Proof<SC> {
 impl<SC, A> System<SC, A>
 where
     SC: StarkGenericConfig,
+    // Two-adicity is needed to re-base the quotient's coefficient slices
+    // onto the trace domain; every FRI-based config is two-adic anyway.
+    Val<SC>: TwoAdicField + Ord,
     A: BaseAir<Val<SC>> + for<'a> Air<ProverConstraintFolder<'a, Val<SC>, SC::Challenge>>,
 {
     /// Generates a STARK proof for the system with a single claim.
@@ -422,13 +428,13 @@ where
         let _g = tracing::info_span!("stark/quotient").entered();
         debug_assert_eq!(intermediate_accumulators.len(), active_indices.len());
         debug_assert_eq!(log_degrees.len(), active_indices.len());
-        let mut quotient_degrees = vec![];
+        let dft = Radix2DitParallel::<Val<SC>>::default();
         let quotient_evaluations = active_indices
             .iter()
             .zip(log_degrees.iter())
             .zip(intermediate_accumulators.iter())
             .enumerate()
-            .flat_map(|(pos, ((&ci, log_degree), next_acc))| {
+            .map(|(pos, ((&ci, log_degree), next_acc))| {
                 let circuit = &self.circuits[ci];
                 let air = &circuit.air;
                 let quotient_degree = circuit.quotient_degree();
@@ -473,17 +479,36 @@ where
                 );
                 let quotient_flat =
                     RowMajorMatrix::new_col(quotient_values).flatten_to_base::<Val<SC>>();
-                // note that, in general, the quotients have a degree that is greater than the trace polynomials,
-                // so for FRI to work so we must split into smaller polynomials
-                let quotient_sub_evaluations =
-                    quotient_domain.split_evals(quotient_degree, quotient_flat);
-                let quotient_sub_domains = quotient_domain.split_domains(quotient_degree);
-                // need to save the quotient degree for later
-                quotient_degrees.push(quotient_degree);
+                // The quotient has degree greater than the trace polynomials,
+                // so for FRI to work it must be split into `quotient_degree`
+                // sub-polynomials of trace degree. Slice its COEFFICIENTS:
+                // `Q(X) = Σᵢ X^{i·n}·cᵢ(X)` with each `cᵢ` of degree < n, and
+                // commit all slices as ONE `q·D`-column matrix on the trace
+                // domain — instead of one matrix per slice on the split
+                // cosets — so the opening phase pays its per-matrix costs
+                // once per circuit rather than once per slice.
+                let coefficients =
+                    dft.coset_idft_batch(quotient_flat, quotient_domain.first_point());
+                let ext_degree = <SC::Challenge as BasedVectorSpace<Val<SC>>>::DIMENSION;
+                let n = 1 << log_degree;
+                let width = quotient_degree * ext_degree;
+                let mut sliced = Vec::with_capacity(n * width);
+                for row in 0..n {
+                    for chunk in 0..quotient_degree {
+                        sliced.extend_from_slice(
+                            &coefficients.values[(chunk * n + row) * ext_degree
+                                ..(chunk * n + row + 1) * ext_degree],
+                        );
+                    }
+                }
+                let quotient_chunks_evals = dft
+                    .coset_dft_batch(
+                        RowMajorMatrix::new(sliced, width),
+                        trace_domain.first_point(),
+                    )
+                    .to_row_major_matrix();
                 acc = *next_acc;
-                quotient_sub_domains
-                    .into_iter()
-                    .zip(quotient_sub_evaluations)
+                (trace_domain, quotient_chunks_evals)
             });
         let (quotient_commit, quotient_data) = pcs.commit(quotient_evaluations);
         challenger.observe(quotient_commit.clone());
@@ -504,16 +529,15 @@ where
         let mut round1_openings = vec![];
         let mut round2_openings = vec![];
         let mut round3_openings = vec![];
-        for pos in 0..active_indices.len() {
-            let log_degree = log_degrees[pos];
-            let quotient_degree = quotient_degrees[pos];
+        for &log_degree in log_degrees.iter() {
             let trace_domain = pcs.natural_domain_for_degree(1 << log_degree);
             let zeta_next = trace_domain
                 .next_point(zeta)
                 .expect("domain has no next point");
             round1_openings.push(vec![zeta, zeta_next]);
             round2_openings.push(vec![zeta, zeta_next]);
-            round3_openings.extend(vec![vec![zeta]; quotient_degree]);
+            // One wide matrix per circuit holds all its quotient slices.
+            round3_openings.push(vec![zeta]);
         }
         // The preprocessed commitment is built once over ALL preprocessed
         // traces at system construction, so its round must carry one entry

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -324,19 +324,9 @@ where
         let mut stage_1_trace_evaluations = vec![];
         let mut stage_2_trace_evaluations = vec![];
         let mut quotient_chunks_evaluations = vec![];
-        let mut last_quotient_i = 0;
         for pos in 0..active_indices.len() {
             let log_degree = log_degrees[pos];
-            let quotient_degree = quotient_degrees[pos];
-            let log_quotient_degree = log2_strict_usize(quotient_degree);
             let trace_domain = pcs.natural_domain_for_degree(1 << log_degree);
-            let quotient_domain =
-                trace_domain.create_disjoint_domain((1 << log_degree) << log_quotient_degree);
-            let quotient_chunks_domains = quotient_domain.split_domains(quotient_degree);
-            let unshifted_quotient_chunks_domains = quotient_chunks_domains
-                .iter()
-                .map(|domain| pcs.natural_domain_for_degree(domain.size()))
-                .collect::<Vec<_>>();
             let zeta_next = trace_domain
                 .next_point(zeta)
                 .ok_or(VerificationError::InvalidProofShape)?;
@@ -354,15 +344,12 @@ where
                     (zeta_next, stage_2_opened_values[pos][1].clone()),
                 ],
             ));
-            let iter = unshifted_quotient_chunks_domains
-                .into_iter()
-                .zip(
-                    quotient_opened_values[last_quotient_i..last_quotient_i + quotient_degree]
-                        .iter(),
-                )
-                .map(|(domain, opened_values)| (domain, vec![(zeta, opened_values[0].clone())]));
-            quotient_chunks_evaluations.extend(iter);
-            last_quotient_i += quotient_degree;
+            // All of a circuit's quotient coefficient slices live in one
+            // matrix on the trace domain, opened once at ζ.
+            quotient_chunks_evaluations.push((
+                trace_domain,
+                vec![(zeta, quotient_opened_values[pos][0].clone())],
+            ));
         }
         // The preprocessed commitment covers ALL preprocessed matrices, in
         // canonical slot order; inactive circuits' matrices are opened at no
@@ -424,7 +411,6 @@ where
         // use the opened values to compute the composition polynomial for each circuit
         // and check that the evaluation of the composition polynomial equals the
         // product of the zerofier with the quotient
-        let mut last_quotient_i = 0;
         for (pos, &ci) in active_indices.iter().enumerate() {
             let circuit = &self.circuits[ci];
             let degree = 1 << log_degrees[pos];
@@ -434,11 +420,7 @@ where
             let stage_1_next_row = &stage_1_opened_values[pos][1];
             let stage_2_row = &stage_2_opened_values[pos][0];
             let stage_2_next_row = &stage_2_opened_values[pos][1];
-            let quotient_chunks = quotient_opened_values
-                [last_quotient_i..last_quotient_i + quotient_degree]
-                .iter()
-                .map(|values| &values[0]);
-            last_quotient_i += quotient_degree;
+            let quotient_row = &quotient_opened_values[pos][0];
 
             // compute the composition polynomial evaluation
             let trace_domain = pcs.natural_domain_for_degree(degree);
@@ -489,30 +471,16 @@ where
             };
             circuit.air.eval(&mut folder);
             let composition_polynomial = folder.accumulator;
-            // compute the quotient evaluation
-            let quotient_domain = trace_domain.create_disjoint_domain(degree * quotient_degree);
-            let quotient_chunks_domains = quotient_domain.split_domains(quotient_degree);
-            let zps = quotient_chunks_domains
-                .iter()
-                .enumerate()
-                .map(|(i, domain)| {
-                    quotient_chunks_domains
-                        .iter()
-                        .enumerate()
-                        .filter(|(j, _)| *j != i)
-                        .map(|(_, other_domain)| {
-                            other_domain.vanishing_poly_at_point(zeta)
-                                * other_domain
-                                    .vanishing_poly_at_point(domain.first_point())
-                                    .inverse()
-                        })
-                        .product::<SC::Challenge>()
-                })
-                .collect::<Vec<_>>();
-            let quotient = quotient_chunks
-                .enumerate()
-                .map(|(ch_i, ch)| zps[ch_i] * from_ext_basis::<Val<SC>, SC::Challenge>(ch))
+            // Recombine the quotient from its coefficient slices:
+            // `Q(ζ) = Σᵢ ζ^{i·n}·cᵢ(ζ)`, with each slice's value read from
+            // the wide quotient matrix opened at ζ.
+            let zeta_pow_n = zeta.exp_power_of_2(log2_strict_usize(degree));
+            let quotient = quotient_row
+                .chunks_exact(extension_d)
+                .zip(zeta_pow_n.powers())
+                .map(|(chunk, zeta_pow)| zeta_pow * from_ext_basis::<Val<SC>, SC::Challenge>(chunk))
                 .sum::<SC::Challenge>();
+            debug_assert_eq!(quotient_row.len(), quotient_degree * extension_d);
 
             // Soundness: OOD check. If any constraint is violated on the trace
             // domain, the composition polynomial is not divisible by the vanishing
@@ -676,24 +644,24 @@ where
             );
             quotient_degrees.push(quotient_degree);
         }
-        let quotient_size: usize = quotient_degrees.iter().sum();
+        // One wide quotient matrix per active circuit, holding all its
+        // coefficient slices, opened at the single point ζ.
         ensure_eq!(
             quotient_opened_values.len(),
-            quotient_size,
+            num_active,
             VerificationError::InvalidProofShape
         );
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..quotient_size {
+        for (pos, quotient_degree) in quotient_degrees.iter().enumerate() {
             // zeta
             let num_openings = 1;
             ensure_eq!(
-                quotient_opened_values[i].len(),
+                quotient_opened_values[pos].len(),
                 num_openings,
                 VerificationError::InvalidProofShape
             );
             ensure_eq!(
-                quotient_opened_values[i][0].len(),
-                <SC::Challenge as BasedVectorSpace<Val<SC>>>::DIMENSION,
+                quotient_opened_values[pos][0].len(),
+                quotient_degree * <SC::Challenge as BasedVectorSpace<Val<SC>>>::DIMENSION,
                 VerificationError::InvalidProofShape
             );
         }


### PR DESCRIPTION
# Commit quotient slices as one matrix per circuit

Changes how the quotient polynomial is committed: instead of one matrix per
degree-`n` chunk on the split sub-cosets, each circuit's quotient is sliced by
**coefficients** — `Q(X) = Σᵢ X^{i·n}·cᵢ(X)`, each `cᵢ` of degree `< n` — and
all `q` slices are committed as a **single `q·D`-column matrix on the trace
domain**, opened once at ζ.

## Motivation

The opening phase's dominant costs are **per-matrix and width-independent**:
barycentric evaluation, the `(p(x) − y)/(x − ζ)` reduction that feeds FRI, and
per-query row extraction each walk the full LDE height once per matrix,
regardless of how many columns the matrix has. Under the old layout a circuit
contributed `q` quotient matrices, so raising the quotient degree multiplied
exactly the work these passes do. Profiling an Aiur-scale system (~500
circuits, quotient degree 4) showed the per-matrix passes were ~80% of
`fri_open`, scaling linearly with quotient matrix count — while the committed
*area* barely changed.

The same disease affected the commit side (one LDE/Merkle pipeline invocation
per tiny `D`-column chunk) and even the proof size: every matrix in a query's
batch opening carries its own length-prefixed vector, ~8 bytes × matrices ×
queries of pure framing.

## The change

**Prover** (`prove_multiple_claims`): after the constraint sweep produces the
quotient's evaluations on the size-`q·n` coset, interpolate once (coset iDFT),
slice the coefficient vector into `q` degree-`< n` polynomials, and evaluate
the sliced `n × q·D` matrix back onto the trace domain (one size-`n` DFT).
The evaluation sweep itself — the expensive part — is untouched; the added
transform work is on `q·D` columns and is negligible. Requires a
`TwoAdicField` bound on the prover's `Val`, which every FRI-based
configuration satisfies.

**Opening round**: the quotient round now has exactly one entry per active
circuit (same shape as stages 1 and 2), instead of `q` chunk entries per
circuit.

**Verifier**: the sub-domain Lagrange recombination — the `zps` products of
vanishing polynomials over the split cosets — collapses to a power series:

```text
Q(ζ) = Σᵢ ζ^{i·n} · cᵢ(ζ)
```

with each `cᵢ(ζ)` read from column-slices of the one wide matrix. This is
both cheaper natively and substantially simpler to port to a recursive
verifier. Shape checks change accordingly (one opened row of `q·D` values per
circuit at the single point ζ).

Soundness is unchanged: each slice is individually degree-bound `< n` by FRI
(same bound as before), the recombination identity is exact, and the layout
is bound into the transcript through the commitment.

## Breaking changes

- Commitment layout, transcript, and proof shape change: proofs from earlier
  versions no longer verify. The quotient round of `Proof::quotient_opened_values`
  now carries one entry per active circuit (a `q·D`-value row at ζ).
- Downstream verifiers (including recursive ones) must switch the quotient
  recombination from the sub-domain `zps` formula to the `ζ^{i·n}` power
  series.

## Testing

The full test suite passes on top of the change (lookup systems, sparse
activation, high-degree circuits, adversarial/tamper tests, serialization
round-trip), and it is exercised end to end downstream by the Ix/Aiur proving
suites (70 prove/verify cases plus BLAKE3/SHA-256 circuits and IxVM kernel
checks).